### PR TITLE
Allow NATS error to be caught before json unmarshal

### DIFF
--- a/schemaregistry/registry.go
+++ b/schemaregistry/registry.go
@@ -261,13 +261,13 @@ func (sr *SchemaRegistry) Add(ctx context.Context, req AddRequest) (*AddResponse
 		return nil, err
 	}
 
-	var addResp AddResponse
-	if err := json.Unmarshal(resp.Data, &addResp); err != nil {
+	err = headersToError(resp.Header)
+	if err != nil {
 		return nil, err
 	}
 
-	err = headersToError(resp.Header)
-	if err != nil {
+	var addResp AddResponse
+	if err := json.Unmarshal(resp.Data, &addResp); err != nil {
 		return nil, err
 	}
 
@@ -284,13 +284,13 @@ func (sr *SchemaRegistry) Get(ctx context.Context, req GetRequest) (*GetResponse
 		return nil, err
 	}
 
-	var getResp GetResponse
-	if err := json.Unmarshal(resp.Data, &getResp); err != nil {
+	err = headersToError(resp.Header)
+	if err != nil {
 		return nil, err
 	}
 
-	err = headersToError(resp.Header)
-	if err != nil {
+	var getResp GetResponse
+	if err := json.Unmarshal(resp.Data, &getResp); err != nil {
 		return nil, err
 	}
 
@@ -307,13 +307,13 @@ func (sr *SchemaRegistry) Update(ctx context.Context, req UpdateRequest) (*Updat
 		return nil, err
 	}
 
-	var updateResp UpdateResponse
-	if err := json.Unmarshal(resp.Data, &updateResp); err != nil {
+	err = headersToError(resp.Header)
+	if err != nil {
 		return nil, err
 	}
 
-	err = headersToError(resp.Header)
-	if err != nil {
+	var updateResp UpdateResponse
+	if err := json.Unmarshal(resp.Data, &updateResp); err != nil {
 		return nil, err
 	}
 
@@ -330,13 +330,13 @@ func (sr *SchemaRegistry) List(ctx context.Context, req ListRequest) (*ListRespo
 		return nil, err
 	}
 
-	var listResp ListResponse
-	if err := json.Unmarshal(resp.Data, &listResp); err != nil {
+	err = headersToError(resp.Header)
+	if err != nil {
 		return nil, err
 	}
 
-	err = headersToError(resp.Header)
-	if err != nil {
+	var listResp ListResponse
+	if err := json.Unmarshal(resp.Data, &listResp); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Moved order of precedence so that the NATS headers are checked for error before attempting to unmarshal as the `resp` may be `nil`.