### PR TITLE
natssysclient: add pagination helpers for monitoring endpoints

### DIFF
--- a/natssysclient/connz.go
+++ b/natssysclient/connz.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"iter"
 	"time"
 
 	"github.com/nats-io/jwt/v2"
@@ -218,4 +219,80 @@ func (s *System) ConnzPing(ctx context.Context, opts ConnzEventOptions) ([]Connz
 		srvConnz = append(srvConnz, connzResp)
 	}
 	return srvConnz, nil
+}
+
+// AllConnz returns an iterator over all connections for a specific server,
+// automatically handling pagination.
+func (s *System) AllConnz(ctx context.Context, id string, opts ConnzEventOptions) iter.Seq2[*ConnzResp, error] {
+	return func(yield func(*ConnzResp, error) bool) {
+		currentOpts := opts
+
+		for {
+			resp, err := s.Connz(ctx, id, currentOpts)
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+
+			if !yield(resp, nil) {
+				return
+			}
+
+			// Check if we've received all connections
+			received := currentOpts.Offset + len(resp.Connz.Conns)
+			if received >= resp.Connz.Total {
+				return
+			}
+
+			// Update offset for next page
+			currentOpts.Offset = received
+		}
+	}
+}
+
+// AllConnzPing returns a slice of iterators, one for each server,
+// automatically handling pagination for each server independently.
+func (s *System) AllConnzPing(ctx context.Context, opts ConnzEventOptions) ([]iter.Seq2[*ConnzResp, error], error) {
+	// First get initial responses from all servers
+	initialResponses, err := s.ConnzPing(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create an iterator for each server
+	iterators := make([]iter.Seq2[*ConnzResp, error], len(initialResponses))
+
+	for i, initial := range initialResponses {
+		// Capture variables for closure
+		serverID := initial.Server.ID
+		firstResp := initial
+
+		iterators[i] = func(yield func(*ConnzResp, error) bool) {
+			// Yield the initial response
+			resp := firstResp
+			if !yield(&resp, nil) {
+				return
+			}
+
+			// Continue pagination for this server if needed
+			currentOpts := opts
+			currentOpts.Offset = opts.Offset + len(firstResp.Connz.Conns)
+
+			for currentOpts.Offset < firstResp.Connz.Total {
+				nextResp, err := s.Connz(ctx, serverID, currentOpts)
+				if err != nil {
+					yield(nil, err)
+					return
+				}
+
+				if !yield(nextResp, nil) {
+					return
+				}
+
+				currentOpts.Offset += len(nextResp.Connz.Conns)
+			}
+		}
+	}
+
+	return iterators, nil
 }

--- a/natssysclient/connz.go
+++ b/natssysclient/connz.go
@@ -240,7 +240,7 @@ func (s *System) AllConnz(ctx context.Context, id string, opts ConnzEventOptions
 
 			// Check if we've received all connections
 			received := currentOpts.Offset + len(resp.Connz.Conns)
-			if received >= resp.Connz.Total {
+			if received >= resp.Connz.Total || len(resp.Connz.Conns) == 0 {
 				return
 			}
 

--- a/natssysclient/jsz_server.go
+++ b/natssysclient/jsz_server.go
@@ -190,7 +190,7 @@ func (s *System) AllJsz(ctx context.Context, id string, opts JszEventOptions) it
 			// Check if we've received all accounts
 			// The total is determined by the Accounts field in JetStreamStats
 			received := currentOpts.Offset + len(resp.JSInfo.AccountDetails)
-			if received >= resp.JSInfo.Accounts {
+			if received >= resp.JSInfo.Accounts || len(resp.JSInfo.AccountDetails) == 0 {
 				return
 			}
 

--- a/natssysclient/subsz_server.go
+++ b/natssysclient/subsz_server.go
@@ -134,7 +134,7 @@ func (s *System) AllServerSubsz(ctx context.Context, id string, opts SubszOption
 
 			// Check if we've received all subscriptions
 			received := currentOpts.Offset + len(resp.Subsz.Subs)
-			if received >= resp.Subsz.Total {
+			if received >= resp.Subsz.Total || len(resp.Subsz.Subs) == 0 {
 				return
 			}
 

--- a/natssysclient/subsz_server.go
+++ b/natssysclient/subsz_server.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"iter"
 	"time"
 )
 
@@ -111,4 +112,80 @@ func (s *System) ServerSubszPing(ctx context.Context, opts SubszOptions) ([]Subs
 		srvSubsz = append(srvSubsz, subszResp)
 	}
 	return srvSubsz, nil
+}
+
+// AllServerSubsz returns an iterator over all subscriptions for a specific server,
+// automatically handling pagination.
+func (s *System) AllServerSubsz(ctx context.Context, id string, opts SubszOptions) iter.Seq2[*SubszResp, error] {
+	return func(yield func(*SubszResp, error) bool) {
+		// Start with the provided offset
+		currentOpts := opts
+
+		for {
+			resp, err := s.ServerSubsz(ctx, id, currentOpts)
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+
+			if !yield(resp, nil) {
+				return
+			}
+
+			// Check if we've received all subscriptions
+			received := currentOpts.Offset + len(resp.Subsz.Subs)
+			if received >= resp.Subsz.Total {
+				return
+			}
+
+			// Update offset for next page
+			currentOpts.Offset = received
+		}
+	}
+}
+
+// AllServerSubszPing returns a slice of iterators, one for each server,
+// automatically handling pagination for each server independently.
+func (s *System) AllServerSubszPing(ctx context.Context, opts SubszOptions) ([]iter.Seq2[*SubszResp, error], error) {
+	// First get initial responses from all servers
+	initialResponses, err := s.ServerSubszPing(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create an iterator for each server
+	iterators := make([]iter.Seq2[*SubszResp, error], len(initialResponses))
+
+	for i, initial := range initialResponses {
+		serverID := initial.Server.ID
+		firstResp := initial
+
+		iterators[i] = func(yield func(*SubszResp, error) bool) {
+			// Yield the initial response
+			resp := firstResp
+			if !yield(&resp, nil) {
+				return
+			}
+
+			// Continue pagination for this server if needed
+			currentOpts := opts
+			currentOpts.Offset = opts.Offset + len(firstResp.Subsz.Subs)
+
+			for currentOpts.Offset < firstResp.Subsz.Total {
+				nextResp, err := s.ServerSubsz(ctx, serverID, currentOpts)
+				if err != nil {
+					yield(nil, err)
+					return
+				}
+
+				if !yield(nextResp, nil) {
+					return
+				}
+
+				currentOpts.Offset += len(nextResp.Subsz.Subs)
+			}
+		}
+	}
+
+	return iterators, nil
 }

--- a/natssysclient/test/jsz_server_test.go
+++ b/natssysclient/test/jsz_server_test.go
@@ -159,7 +159,12 @@ func TestJszPing(t *testing.T) {
 			if s.ID() == jsz.Server.ID {
 				seen = true
 			}
-			streamsNum += len(jsz.JSInfo.AccountDetails[0].Streams)
+			for _, acc := range jsz.JSInfo.AccountDetails {
+				if acc.Name != "JS" {
+					continue
+				}
+				streamsNum += len(acc.Streams)
+			}
 		}
 		if !seen {
 			t.Fatalf("Expected server %q in the response", s.Name())
@@ -168,4 +173,135 @@ func TestJszPing(t *testing.T) {
 			t.Fatalf("Expected stream details in the response")
 		}
 	}
+}
+
+func TestAllJszPagination(t *testing.T) {
+	c := SetupCluster(t)
+	defer c.Shutdown()
+
+	var urls []string
+	for _, s := range c.servers {
+		urls = append(urls, s.ClientURL())
+	}
+
+	sysConn, err := nats.Connect(strings.Join(urls, ","), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error establishing connection: %s", err)
+	}
+
+	sys, err := natssysclient.NewSysClient(sysConn)
+	if err != nil {
+		t.Fatalf("Error creating system client: %s", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	serverID := c.servers[0].ID()
+
+	t.Run("without accounts", func(t *testing.T) {
+		opts := natssysclient.JszEventOptions{
+			JszOptions: natssysclient.JszOptions{
+				Accounts: false,
+			},
+		}
+
+		var responseCount int
+		for resp, err := range sys.AllJsz(ctx, serverID, opts) {
+			if err != nil {
+				t.Fatalf("Error during iteration: %s", err)
+			}
+			responseCount++
+			if len(resp.JSInfo.AccountDetails) > 0 {
+				t.Error("Expected no account details when Accounts is false")
+			}
+		}
+
+		if responseCount != 1 {
+			t.Errorf("Expected exactly 1 response without pagination, got %d", responseCount)
+		}
+	})
+
+	t.Run("single server pagination", func(t *testing.T) {
+		opts := natssysclient.JszEventOptions{
+			JszOptions: natssysclient.JszOptions{
+				Accounts: true,
+				Limit:    1,
+			},
+		}
+
+		var totalAccounts int
+		var responses []*natssysclient.JSZResp
+
+		for resp, err := range sys.AllJsz(ctx, serverID, opts) {
+			if err != nil {
+				t.Fatalf("Error during pagination: %s", err)
+			}
+			responses = append(responses, resp)
+			totalAccounts += len(resp.JSInfo.AccountDetails)
+		}
+
+		if len(responses) != 3 {
+			t.Errorf("Expected exactly 3 responses (3 JS accounts with limit=1), got %d", len(responses))
+		}
+
+		firstResp := responses[0]
+		if totalAccounts != firstResp.JSInfo.Accounts {
+			t.Errorf("Total accounts mismatch: got %d, want %d", totalAccounts, firstResp.JSInfo.Accounts)
+		}
+	})
+
+	t.Run("ping all servers pagination", func(t *testing.T) {
+		opts := natssysclient.JszEventOptions{
+			JszOptions: natssysclient.JszOptions{
+				Accounts: true,
+				Limit:    1,
+			},
+		}
+
+		serverIterators, err := sys.AllJszPing(ctx, opts)
+		if err != nil {
+			t.Fatalf("Error getting server iterators: %s", err)
+		}
+
+		if len(serverIterators) != len(c.servers) {
+			t.Errorf("Expected %d iterators, got %d", len(c.servers), len(serverIterators))
+		}
+
+		var totalResponses int
+		var totalAccounts int
+		responsesByServer := make(map[string]int)
+
+		for _, iter := range serverIterators {
+			for resp, err := range iter {
+				if err != nil {
+					t.Fatalf("Error during ping pagination: %s", err)
+				}
+				totalResponses++
+				totalAccounts += len(resp.JSInfo.AccountDetails)
+				responsesByServer[resp.Server.ID]++
+			}
+		}
+
+		expectedAccountsPerServer := 3
+		expectedTotalResponses := len(c.servers) * expectedAccountsPerServer
+
+		if totalResponses != expectedTotalResponses {
+			t.Errorf("Expected exactly %d responses total (3 servers * 3 accounts), got %d",
+				expectedTotalResponses, totalResponses)
+		}
+
+		for serverID, count := range responsesByServer {
+			if count != expectedAccountsPerServer {
+				t.Errorf("Server %s: expected exactly %d responses, got %d",
+					serverID, expectedAccountsPerServer, count)
+			}
+		}
+
+		expectedTotalAccounts := len(c.servers) * expectedAccountsPerServer
+		if totalAccounts != expectedTotalAccounts {
+			t.Errorf("Expected exactly %d total accounts, got %d",
+				expectedTotalAccounts, totalAccounts)
+		}
+	})
 }

--- a/natssysclient/test/subsz_server_test.go
+++ b/natssysclient/test/subsz_server_test.go
@@ -16,6 +16,7 @@ package test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -163,4 +164,125 @@ func TestSubszPing(t *testing.T) {
 			t.Fatalf("Expected server %q in the response", s.Name())
 		}
 	}
+}
+
+func TestAllServerSubszPagination(t *testing.T) {
+	c := SetupCluster(t)
+	defer c.Shutdown()
+
+	var urls []string
+	for _, s := range c.servers {
+		urls = append(urls, s.ClientURL())
+	}
+
+	sysConn, err := nats.Connect(strings.Join(urls, ","), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error establishing connection: %s", err)
+	}
+
+	var allConns []*nats.Conn
+	defer func() {
+		for _, conn := range allConns {
+			conn.Close()
+		}
+	}()
+
+	for i, server := range c.servers {
+		nc, err := nats.Connect(server.ClientURL())
+		if err != nil {
+			t.Fatalf("Error establishing connection to server %d: %s", i, err)
+		}
+		allConns = append(allConns, nc)
+
+		for j := range 10 {
+			_, err := nc.Subscribe(fmt.Sprintf("server%d.sub%d", i, j), func(msg *nats.Msg) {})
+			if err != nil {
+				t.Fatalf("Error creating subscription %d on server %d: %s", j, i, err)
+			}
+		}
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	sys, err := natssysclient.NewSysClient(sysConn)
+	if err != nil {
+		t.Fatalf("Error creating system client: %s", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	serverID := c.servers[0].ID()
+
+	t.Run("single server pagination", func(t *testing.T) {
+		t.Skip("Skipping due to server bug: https://github.com/nats-io/nats-server/pull/7009")
+
+		opts := natssysclient.SubszOptions{
+			Limit:         5,
+			Subscriptions: true,
+		}
+
+		var totalSubs int
+		var responses []*natssysclient.SubszResp
+
+		for resp, err := range sys.AllServerSubsz(ctx, serverID, opts) {
+			if err != nil {
+				t.Fatalf("Error during pagination: %s", err)
+			}
+			responses = append(responses, resp)
+			totalSubs += len(resp.Subsz.Subs)
+		}
+
+		if len(responses) < 2 {
+			t.Errorf("Expected at least 2 responses with limit=5 and 10+ subscriptions, got %d", len(responses))
+		}
+
+		firstResp := responses[0]
+		if totalSubs != firstResp.Subsz.Total {
+			t.Errorf("Total subscriptions mismatch: got %d, want %d", totalSubs, firstResp.Subsz.Total)
+		}
+	})
+
+	t.Run("ping all servers pagination", func(t *testing.T) {
+		t.Skip("Skipping due to server bug: https://github.com/nats-io/nats-server/pull/7009")
+
+		opts := natssysclient.SubszOptions{
+			Limit:         3,
+			Subscriptions: true,
+		}
+
+		serverIterators, err := sys.AllServerSubszPing(ctx, opts)
+		if err != nil {
+			t.Fatalf("Error getting server iterators: %s", err)
+		}
+
+		if len(serverIterators) != len(c.servers) {
+			t.Errorf("Expected %d iterators, got %d", len(c.servers), len(serverIterators))
+		}
+
+		var totalResponses int
+		var totalSubs int
+		responsesByServer := make(map[string]int)
+
+		for _, iter := range serverIterators {
+			for resp, err := range iter {
+				if err != nil {
+					t.Fatalf("Error during ping pagination: %s", err)
+				}
+				totalResponses++
+				totalSubs += len(resp.Subsz.Subs)
+				responsesByServer[resp.Server.ID]++
+			}
+		}
+
+		if totalResponses < len(c.servers)*3 {
+			t.Errorf("Expected at least %d responses total, got %d", len(c.servers)*3, totalResponses)
+		}
+
+		for serverID, count := range responsesByServer {
+			if count < 3 {
+				t.Errorf("Server %s should have at least 3 paginated responses, got %d", serverID, count)
+			}
+		}
+	})
 }

--- a/natssysclient/test/testdata/s1.conf
+++ b/natssysclient/test/testdata/s1.conf
@@ -7,6 +7,14 @@ accounts {
   jetstream: enabled
   users: [ {user: pp, password: foo} ]
  }
+ JS2 {
+  jetstream: enabled
+  users: [ {user: user2, password: pass2} ]
+ }
+ JS3 {
+  jetstream: enabled
+  users: [ {user: user3, password: pass3} ]
+ }
 }
 
 jetstream {

--- a/natssysclient/test/testdata/s2.conf
+++ b/natssysclient/test/testdata/s2.conf
@@ -7,6 +7,14 @@ accounts {
   jetstream: enabled
   users: [ {user: pp, password: foo} ]
  }
+ JS2 {
+  jetstream: enabled
+  users: [ {user: user2, password: pass2} ]
+ }
+ JS3 {
+  jetstream: enabled
+  users: [ {user: user3, password: pass3} ]
+ }
 }
 
 jetstream {

--- a/natssysclient/test/testdata/s3.conf
+++ b/natssysclient/test/testdata/s3.conf
@@ -7,6 +7,14 @@ accounts {
   jetstream: enabled
   users: [ {user: pp, password: foo} ]
  }
+ JS2 {
+  jetstream: enabled
+  users: [ {user: user2, password: pass2} ]
+ }
+ JS3 {
+  jetstream: enabled
+  users: [ {user: user3, password: pass3} ]
+ }
 }
 
 jetstream {


### PR DESCRIPTION
Add pagination helpers for connz, subsz and jsz, both for single server and ping variants

- Some Subsz pagination tests are skipped due to a NATS server bug where the Total field is incorrectly set to the limit value. This has been fixed in nats-io/nats-server#7009.

Fixes #11