### PR TITLE
Fix Batch Ack unmarshaling

### DIFF
--- a/jetstreamext/publishbatch.go
+++ b/jetstreamext/publishbatch.go
@@ -104,10 +104,10 @@ type (
 		Value string `json:"val,omitempty"`
 
 		// BatchID is the unique identifier for the batch.
-		BatchID string `json:"batch_id,omitempty"`
+		BatchID string `json:"batch,omitempty"`
 
 		// BatchSize is the number of messages in the batch.
-		BatchSize int `json:"batch_size,omitempty"`
+		BatchSize int `json:"count,omitempty"`
 	}
 
 	batchPublisher struct {

--- a/jetstreamext/test/publishbatch_test.go
+++ b/jetstreamext/test/publishbatch_test.go
@@ -88,6 +88,14 @@ func TestBatchPublisher(t *testing.T) {
 			t.Fatal("Expected non-nil BatchAck")
 		}
 
+		if ack.BatchSize != 3 {
+			t.Fatalf("Expected BatchAck.BatchSize to be 3, got %d", ack.BatchSize)
+		}
+
+		if ack.BatchID == "" {
+			t.Fatal("Expected non-empty BatchAck.BatchID")
+		}
+
 		// Verify batch is closed
 		if !batch.IsClosed() {
 			t.Fatal("Expected batch to be closed after commit")


### PR DESCRIPTION
The field names for batch ack are different, which resulted in empty values.

Signed-off-by: Tomasz Pietrek <tomasz@synadia.com>