### PR TITLE
Improve member name being limited to 16 characters

### DIFF
--- a/pcgroups/elastic_stream_consumer_group.go
+++ b/pcgroups/elastic_stream_consumer_group.go
@@ -699,7 +699,7 @@ func (instance *ElasticConsumerGroupConsumerInstance) joinMemberConsumer() {
 	config.Name = instance.MemberName
 	config.FilterSubjects = filters
 
-	config.PriorityGroups = []string{instance.MemberName}
+	config.PriorityGroups = []string{priorityGroupName}
 	config.PriorityPolicy = jetstream.PriorityPolicyPinned
 	config.PinnedTTL = config.AckWait
 
@@ -746,7 +746,7 @@ func (instance *ElasticConsumerGroupConsumerInstance) tryCreateConsumer(ctx cont
 func (instance *ElasticConsumerGroupConsumerInstance) startConsuming() {
 	var err error
 
-	instance.consumerConsumeContext, err = instance.consumer.Consume(instance.consumerCallback, jetstream.PullExpiry(pullTimeout), jetstream.PullPriorityGroup(instance.MemberName))
+	instance.consumerConsumeContext, err = instance.consumer.Consume(instance.consumerCallback, jetstream.PullExpiry(pullTimeout), jetstream.PullPriorityGroup(priorityGroupName))
 	if err != nil {
 		log.Printf("Error starting to consume on my consumer: %v\n", err)
 		return
@@ -774,7 +774,7 @@ func (instance *ElasticConsumerGroupConsumerInstance) processMembershipChange(ct
 		ci, err := instance.consumer.Info(ctx)
 		if err == nil { // ignoring error as the consumer may not exist yet
 			if slices.ContainsFunc(ci.PriorityGroups, func(pg jetstream.PriorityGroupState) bool {
-				return pg.Group == instance.MemberName && pg.PinnedClientID == instance.currentPinnedID
+				return pg.Group == priorityGroupName && pg.PinnedClientID == instance.currentPinnedID
 			}) {
 				isPinned = true
 			}

--- a/pcgroups/static_stream_consumer_group.go
+++ b/pcgroups/static_stream_consumer_group.go
@@ -413,7 +413,7 @@ func (instance *StaticConsumerGroupConsumerInstance) joinMemberConsumerStatic(ct
 	config.Durable = composeStaticConsumerName(instance.ConsumerGroupName, instance.MemberName)
 	config.FilterSubjects = filters
 
-	config.PriorityGroups = []string{instance.MemberName}
+	config.PriorityGroups = []string{priorityGroupName}
 	config.PriorityPolicy = jetstream.PriorityPolicyPinned
 	config.PinnedTTL = config.AckWait
 
@@ -431,7 +431,7 @@ func (instance *StaticConsumerGroupConsumerInstance) joinMemberConsumerStatic(ct
 func (instance *StaticConsumerGroupConsumerInstance) startConsuming() {
 	var err error
 
-	instance.consumerConsumeContext, err = instance.consumer.Consume(instance.consumerCallback, jetstream.PullExpiry(pullTimeout), jetstream.PullPriorityGroup(instance.MemberName))
+	instance.consumerConsumeContext, err = instance.consumer.Consume(instance.consumerCallback, jetstream.PullExpiry(pullTimeout), jetstream.PullPriorityGroup(priorityGroupName))
 	if err != nil {
 		log.Printf("Error starting to consume on my consumer: %v\n", err)
 		return

--- a/pcgroups/stream_consumer_group.go
+++ b/pcgroups/stream_consumer_group.go
@@ -32,6 +32,8 @@ const (
 	consumerIdleTimeout = 2 * pullTimeout
 )
 
+const priorityGroupName = "PCG"
+
 type MemberMapping struct {
 	Member     string `json:"member"`
 	Partitions []int  `json:"partitions"`


### PR DESCRIPTION
Initially used the member name as the consumer's priority group name which can be limiting since priority group names are limited to 16 characters. Now using "PCG" as the priority group name since it doesn't need to be different for every member since each member is its own consumer.

Warning: breaking change. To migrate without deleting and recreating a consumer group:

For elastic:
- Stop all the instances of the consuming application for all members.
- Wait at least 6 seconds.
- Restart the instances of the consuming application with the new version of this library.

For static:
- Stop all the instances of the consuming application for all members.
- Edit the configuration of the consumers defined for the group on the stream (name format: `<consumer group name>-<member name>`), e.g. `nats consumer edit <stream name> <consumer name>-<member name> -i`: change the value of the single entry in the `priority_groups` array to `"PCG"`.
- Restart the instances of the consuming application with the new version of this library.

Fixes #33