### PR TITLE
natssysclient: add server-scoped monitoring endpoints

### DIFF
--- a/natssysclient/README.md
+++ b/natssysclient/README.md
@@ -16,7 +16,27 @@
 
 NATS System API Client exposes APIs to interact with the [NATS server monitoring endpoints](https://docs.nats.io/running-a-nats-service/configuration/sys_accounts).
 
-> **Note**: All response structures are compatible with the NATS server v2.10.23 and will be updated to support future additions.
+> **Note**: All response structures target NATS server v2.10.23. Endpoints marked **(2.11+)** below require a newer server.
+
+## Supported endpoints
+
+Server-scoped (`$SYS.REQ.SERVER.<id|PING>.<NAME>`):
+
+- `VARZ` — general server information (`Varz`, `VarzPing`)
+- `STATSZ` — server statistics (`ServerStatsz`, `ServerStatszPing`)
+- `CONNZ` — connection details (`Connz`, `ConnzPing`, `AllConnz`, `AllConnzPing`)
+- `SUBSZ` — subscription details (`ServerSubsz`, `ServerSubszPing`, `AllServerSubsz`, `AllServerSubszPing`)
+- `HEALTHZ` — health check (`Healthz`, `HealthzPing`)
+- `JSZ` — JetStream details (`Jsz`, `JszPing`, `AllJsz`, `AllJszPing`)
+- `IDZ` — basic server identification (`Idz`, `IdzPing`)
+- `ROUTEZ` — route connections (`Routez`, `RoutezPing`)
+- `GATEWAYZ` — gateway connections (`Gatewayz`, `GatewayzPing`)
+- `LEAFZ` — leafnode connections (`Leafz`, `LeafzPing`)
+- `ACCOUNTZ` — account information (`Accountz`, `AccountzPing`)
+- `PROFILEZ` — runtime profiling data (`Profilez`, `ProfilezPing`)
+- `EXPVARZ` — runtime variables (`Expvarz`, `ExpvarzPing`) **(2.11+)**
+- `IPQUEUESZ` — internal producer queues (`Ipqueuesz`, `IpqueueszPing`) **(2.11+)**
+- `RAFTZ` — Raft group state (`Raftz`, `RaftzPing`) **(2.11+)**
 
 ## Installation
 

--- a/natssysclient/accountz.go
+++ b/natssysclient/accountz.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Synadia Communications Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package natssysclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/nats-io/jwt/v2"
+)
+
+type (
+	// AccountzResp is the response from an Accountz request.
+	AccountzResp struct {
+		Server   ServerInfo `json:"server"`
+		Accountz Accountz   `json:"data"`
+		Error    APIError   `json:"error,omitempty"`
+	}
+
+	// Accountz contains information about accounts on a server.
+	// When requested without a specific account, only Accounts is populated with the list of known account names.
+	// When a specific account is requested, Account contains the full account details.
+	Accountz struct {
+		ID            string       `json:"server_id"`
+		Now           time.Time    `json:"now"`
+		SystemAccount string       `json:"system_account,omitempty"`
+		Accounts      []string     `json:"accounts,omitempty"`
+		Account       *AccountInfo `json:"account_detail,omitempty"`
+	}
+
+	// AccountInfo contains detailed information about a single account.
+	AccountInfo struct {
+		AccountName string               `json:"account_name"`
+		LastUpdate  time.Time            `json:"update_time,omitempty"`
+		IsSystem    bool                 `json:"is_system,omitempty"`
+		Expired     bool                 `json:"expired"`
+		Complete    bool                 `json:"complete"`
+		JetStream   bool                 `json:"jetstream_enabled"`
+		LeafCnt     int                  `json:"leafnode_connections"`
+		ClientCnt   int                  `json:"client_connections"`
+		SubCnt      uint32               `json:"subscriptions"`
+		Mappings    ExtMap               `json:"mappings,omitempty"`
+		Exports     []ExtExport          `json:"exports,omitempty"`
+		Imports     []ExtImport          `json:"imports,omitempty"`
+		Jwt         string               `json:"jwt,omitempty"`
+		IssuerKey   string               `json:"issuer_key,omitempty"`
+		NameTag     string               `json:"name_tag,omitempty"`
+		Tags        jwt.TagList          `json:"tags,omitempty"`
+		Claim       *jwt.AccountClaims   `json:"decoded_jwt,omitempty"`
+		Vr          []ExtVrIssues        `json:"validation_result_jwt,omitempty"`
+		RevokedUser map[string]time.Time `json:"revoked_user,omitempty"`
+		Sublist     *SublistStats        `json:"sublist_stats,omitempty"`
+		Responses   map[string]ExtImport `json:"responses,omitempty"`
+	}
+
+	// ExtMap is the map of subject mappings on an account.
+	ExtMap map[string][]*MapDest
+
+	// MapDest describes a single weighted destination for a subject mapping.
+	MapDest struct {
+		Subject string `json:"subject"`
+		Weight  uint8  `json:"weight"`
+		Cluster string `json:"cluster,omitempty"`
+	}
+
+	// ExtExport is a wrapper around jwt.Export adding account-scoped metadata.
+	ExtExport struct {
+		jwt.Export
+		ApprovedAccounts []string             `json:"approved_accounts,omitempty"`
+		RevokedAct       map[string]time.Time `json:"revoked_activations,omitempty"`
+	}
+
+	// ExtImport is a wrapper around jwt.Import adding account-scoped metadata
+	// and latency-tracking state. M1 carries the last-observed ServiceLatency
+	// measurement as raw JSON: its concrete server-side type transitively depends
+	// on nats-server internals (TypedEvent, ClientInfo) that are not exported by
+	// this module; decode it yourself against the shape published by nats-server
+	// if you need the fields.
+	ExtImport struct {
+		jwt.Import
+		Invalid     bool                `json:"invalid"`
+		Share       bool                `json:"share"`
+		Tracking    bool                `json:"tracking"`
+		TrackingHdr http.Header         `json:"tracking_header,omitempty"`
+		Latency     *jwt.ServiceLatency `json:"latency,omitempty"`
+		M1          json.RawMessage     `json:"m1,omitempty"`
+	}
+
+	// ExtVrIssues is a single JWT claim validation issue.
+	ExtVrIssues struct {
+		Description string `json:"description"`
+		Blocking    bool   `json:"blocking"`
+		Time        bool   `json:"time_check"`
+	}
+
+	// AccountzOptions are the options passed to Accountz.
+	AccountzOptions struct {
+		// Account is the name of the account to request details for.
+		// When empty, the response only contains the list of account names.
+		Account string `json:"account"`
+	}
+
+	// AccountzEventOptions are the options passed to Accountz requests issued over the system events subject.
+	AccountzEventOptions struct {
+		AccountzOptions
+		EventFilterOptions
+	}
+)
+
+// Accountz returns account information from a specific server.
+func (s *System) Accountz(ctx context.Context, id string, opts AccountzEventOptions) (*AccountzResp, error) {
+	payload, err := json.Marshal(opts)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.requestByID(ctx, id, srvAccountzSubj, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	var accountzResp AccountzResp
+	if err := json.Unmarshal(resp.Data, &accountzResp); err != nil {
+		return nil, err
+	}
+
+	return &accountzResp, nil
+}
+
+// AccountzPing returns account information from all servers.
+func (s *System) AccountzPing(ctx context.Context, opts AccountzEventOptions) ([]AccountzResp, error) {
+	subj := fmt.Sprintf(srvAccountzSubj, "PING")
+	payload, err := json.Marshal(opts)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.pingServers(ctx, subj, payload)
+	if err != nil {
+		return nil, err
+	}
+	srvAccountz := make([]AccountzResp, 0, len(resp))
+	for _, msg := range resp {
+		var accountzResp AccountzResp
+		if err := json.Unmarshal(msg.Data, &accountzResp); err != nil {
+			return nil, err
+		}
+		srvAccountz = append(srvAccountz, accountzResp)
+	}
+	return srvAccountz, nil
+}

--- a/natssysclient/api.go
+++ b/natssysclient/api.go
@@ -19,12 +19,21 @@ const (
 )
 
 const (
-	srvVarzSubj    = "$SYS.REQ.SERVER.%s.VARZ"
-	srvStatszSubj  = "$SYS.REQ.SERVER.%s.STATSZ"
-	srvConnzSubj   = "$SYS.REQ.SERVER.%s.CONNZ"
-	srvSubszSubj   = "$SYS.REQ.SERVER.%s.SUBSZ"
-	srvHealthzSubj = "$SYS.REQ.SERVER.%s.HEALTHZ"
-	srvJszSubj     = "$SYS.REQ.SERVER.%s.JSZ"
+	srvVarzSubj      = "$SYS.REQ.SERVER.%s.VARZ"
+	srvStatszSubj    = "$SYS.REQ.SERVER.%s.STATSZ"
+	srvConnzSubj     = "$SYS.REQ.SERVER.%s.CONNZ"
+	srvSubszSubj     = "$SYS.REQ.SERVER.%s.SUBSZ"
+	srvHealthzSubj   = "$SYS.REQ.SERVER.%s.HEALTHZ"
+	srvJszSubj       = "$SYS.REQ.SERVER.%s.JSZ"
+	srvIdzSubj       = "$SYS.REQ.SERVER.%s.IDZ"
+	srvRoutezSubj    = "$SYS.REQ.SERVER.%s.ROUTEZ"
+	srvGatewayzSubj  = "$SYS.REQ.SERVER.%s.GATEWAYZ"
+	srvLeafzSubj     = "$SYS.REQ.SERVER.%s.LEAFZ"
+	srvAccountzSubj  = "$SYS.REQ.SERVER.%s.ACCOUNTZ"
+	srvProfilezSubj  = "$SYS.REQ.SERVER.%s.PROFILEZ"
+	srvExpvarzSubj   = "$SYS.REQ.SERVER.%s.EXPVARZ"
+	srvIpqueueszSubj = "$SYS.REQ.SERVER.%s.IPQUEUESZ"
+	srvRaftzSubj     = "$SYS.REQ.SERVER.%s.RAFTZ"
 )
 
 var (
@@ -157,7 +166,10 @@ func (s *System) pingServers(ctx context.Context, subject string, data []byte) (
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrRequest, err)
 	}
-	msgs := make([]*nats.Msg, 0)
+	var msgs []*nats.Msg
+	if s.opts.serverCount > 0 {
+		msgs = make([]*nats.Msg, 0, s.opts.serverCount)
+	}
 	for msg, err := range iter {
 		if err != nil {
 			return nil, fmt.Errorf("%w: %s", ErrPingResponse, err)

--- a/natssysclient/expvarz.go
+++ b/natssysclient/expvarz.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Synadia Communications Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package natssysclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+type (
+	// ExpvarzResp is the response from an Expvarz request.
+	ExpvarzResp struct {
+		Server  ServerInfo    `json:"server"`
+		Expvarz ExpvarzStatus `json:"data"`
+		Error   APIError      `json:"error,omitempty"`
+	}
+
+	// ExpvarzStatus contains the runtime variables exported via Go's expvar package.
+	ExpvarzStatus struct {
+		Memstats json.RawMessage `json:"memstats"`
+		Cmdline  json.RawMessage `json:"cmdline"`
+	}
+
+	// ExpvarzEventOptions are the options passed to Expvarz requests issued over the system events subject.
+	ExpvarzEventOptions struct {
+		EventFilterOptions
+	}
+)
+
+// Expvarz returns runtime variables from a specific server.
+func (s *System) Expvarz(ctx context.Context, id string, opts ExpvarzEventOptions) (*ExpvarzResp, error) {
+	payload, err := json.Marshal(opts)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.requestByID(ctx, id, srvExpvarzSubj, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	var expvarzResp ExpvarzResp
+	if err := json.Unmarshal(resp.Data, &expvarzResp); err != nil {
+		return nil, err
+	}
+
+	return &expvarzResp, nil
+}
+
+// ExpvarzPing returns runtime variables from all servers.
+func (s *System) ExpvarzPing(ctx context.Context, opts ExpvarzEventOptions) ([]ExpvarzResp, error) {
+	subj := fmt.Sprintf(srvExpvarzSubj, "PING")
+	payload, err := json.Marshal(opts)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.pingServers(ctx, subj, payload)
+	if err != nil {
+		return nil, err
+	}
+	srvExpvarz := make([]ExpvarzResp, 0, len(resp))
+	for _, msg := range resp {
+		var expvarzResp ExpvarzResp
+		if err := json.Unmarshal(msg.Data, &expvarzResp); err != nil {
+			return nil, err
+		}
+		srvExpvarz = append(srvExpvarz, expvarzResp)
+	}
+	return srvExpvarz, nil
+}

--- a/natssysclient/gatewayz.go
+++ b/natssysclient/gatewayz.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Synadia Communications Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package natssysclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+type (
+	// GatewayzResp is the response from a Gatewayz request.
+	GatewayzResp struct {
+		Server   ServerInfo `json:"server"`
+		Gatewayz Gatewayz   `json:"data"`
+		Error    APIError   `json:"error,omitempty"`
+	}
+
+	// Gatewayz represents detailed information on Gateways.
+	Gatewayz struct {
+		ID               string                       `json:"server_id"`
+		Now              time.Time                    `json:"now"`
+		Name             string                       `json:"name,omitempty"`
+		Host             string                       `json:"host,omitempty"`
+		Port             int                          `json:"port,omitempty"`
+		OutboundGateways map[string]*RemoteGatewayz   `json:"outbound_gateways"`
+		InboundGateways  map[string][]*RemoteGatewayz `json:"inbound_gateways"`
+	}
+
+	// RemoteGatewayz represents information about an outbound connection to a gateway.
+	RemoteGatewayz struct {
+		IsConfigured bool               `json:"configured"`
+		Connection   *ConnInfo          `json:"connection,omitempty"`
+		Accounts     []*AccountGatewayz `json:"accounts,omitempty"`
+	}
+
+	// AccountGatewayz represents interest mode for an account on a gateway.
+	AccountGatewayz struct {
+		Name                  string      `json:"name"`
+		InterestMode          string      `json:"interest_mode"`
+		NoInterestCount       int         `json:"no_interest_count,omitempty"`
+		InterestOnlyThreshold int         `json:"interest_only_threshold,omitempty"`
+		TotalSubscriptions    int         `json:"num_subs,omitempty"`
+		NumQueueSubscriptions int         `json:"num_queue_subs,omitempty"`
+		Subs                  []string    `json:"subscriptions_list,omitempty"`
+		SubsDetail            []SubDetail `json:"subscriptions_list_detail,omitempty"`
+	}
+
+	// GatewayzOptions are the options passed to Gatewayz.
+	GatewayzOptions struct {
+		// Name filters the list to a single named remote gateway.
+		Name string `json:"name"`
+
+		// Accounts indicates if accounts with their interest should be included in the results.
+		Accounts bool `json:"accounts"`
+
+		// AccountName limits the list of accounts to a single account (implies Accounts).
+		AccountName string `json:"account_name"`
+
+		// AccountSubscriptions indicates if subscriptions should be included in the results.
+		// Only used if Accounts or AccountName are specified.
+		AccountSubscriptions bool `json:"subscriptions"`
+
+		// AccountSubscriptionsDetail indicates if subscription details should be included in the results.
+		// Only used if Accounts or AccountName are specified.
+		AccountSubscriptionsDetail bool `json:"subscriptions_detail"`
+	}
+
+	// GatewayzEventOptions are the options passed to Gatewayz requests issued over the system events subject.
+	GatewayzEventOptions struct {
+		GatewayzOptions
+		EventFilterOptions
+	}
+)
+
+// Gatewayz returns gateway connection details from a specific server.
+func (s *System) Gatewayz(ctx context.Context, id string, opts GatewayzEventOptions) (*GatewayzResp, error) {
+	payload, err := json.Marshal(opts)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.requestByID(ctx, id, srvGatewayzSubj, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	var gatewayzResp GatewayzResp
+	if err := json.Unmarshal(resp.Data, &gatewayzResp); err != nil {
+		return nil, err
+	}
+
+	return &gatewayzResp, nil
+}
+
+// GatewayzPing returns gateway connection details from all servers.
+func (s *System) GatewayzPing(ctx context.Context, opts GatewayzEventOptions) ([]GatewayzResp, error) {
+	subj := fmt.Sprintf(srvGatewayzSubj, "PING")
+	payload, err := json.Marshal(opts)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.pingServers(ctx, subj, payload)
+	if err != nil {
+		return nil, err
+	}
+	srvGatewayz := make([]GatewayzResp, 0, len(resp))
+	for _, msg := range resp {
+		var gatewayzResp GatewayzResp
+		if err := json.Unmarshal(msg.Data, &gatewayzResp); err != nil {
+			return nil, err
+		}
+		srvGatewayz = append(srvGatewayz, gatewayzResp)
+	}
+	return srvGatewayz, nil
+}

--- a/natssysclient/idz.go
+++ b/natssysclient/idz.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Synadia Communications Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package natssysclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// ServerID is the response from the IDZ request. Unlike other endpoints,
+// IDZ returns the server identification info directly without a response envelope.
+type ServerID struct {
+	Name string `json:"name"`
+	Host string `json:"host"`
+	ID   string `json:"id"`
+}
+
+// Idz returns basic identification information of a specific server.
+func (s *System) Idz(ctx context.Context, id string) (*ServerID, error) {
+	resp, err := s.requestByID(ctx, id, srvIdzSubj, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var idzResp ServerID
+	if err := json.Unmarshal(resp.Data, &idzResp); err != nil {
+		return nil, err
+	}
+
+	return &idzResp, nil
+}
+
+// IdzPing returns basic identification information from all servers.
+func (s *System) IdzPing(ctx context.Context) ([]ServerID, error) {
+	subj := fmt.Sprintf(srvIdzSubj, "PING")
+	resp, err := s.pingServers(ctx, subj, nil)
+	if err != nil {
+		return nil, err
+	}
+	srvIdz := make([]ServerID, 0, len(resp))
+	for _, msg := range resp {
+		var idzResp ServerID
+		if err := json.Unmarshal(msg.Data, &idzResp); err != nil {
+			return nil, err
+		}
+		srvIdz = append(srvIdz, idzResp)
+	}
+	return srvIdz, nil
+}

--- a/natssysclient/ipqueuesz.go
+++ b/natssysclient/ipqueuesz.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Synadia Communications Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package natssysclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+type (
+	// IpqueueszResp is the response from an Ipqueuesz request.
+	IpqueueszResp struct {
+		Server    ServerInfo      `json:"server"`
+		Ipqueuesz IpqueueszStatus `json:"data"`
+		Error     APIError        `json:"error,omitempty"`
+	}
+
+	// IpqueueszStatus maps IPQ names to their current state.
+	IpqueueszStatus map[string]IpqueueszStatusIPQ
+
+	// IpqueueszStatusIPQ contains the state of a single IPQ (internal producer queue).
+	IpqueueszStatusIPQ struct {
+		Pending    int `json:"pending"`
+		InProgress int `json:"in_progress,omitempty"`
+	}
+
+	// IpqueueszOptions are the options passed to Ipqueuesz.
+	IpqueueszOptions struct {
+		// All indicates that queues with no pending or in-progress items should also be returned.
+		All bool `json:"all"`
+		// Filter limits the returned queues to those whose name contains the given substring.
+		Filter string `json:"filter"`
+	}
+
+	// IpqueueszEventOptions are the options passed to Ipqueuesz requests issued over the system events subject.
+	IpqueueszEventOptions struct {
+		EventFilterOptions
+		IpqueueszOptions
+	}
+)
+
+// Ipqueuesz returns the internal producer queue state from a specific server.
+func (s *System) Ipqueuesz(ctx context.Context, id string, opts IpqueueszEventOptions) (*IpqueueszResp, error) {
+	payload, err := json.Marshal(opts)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.requestByID(ctx, id, srvIpqueueszSubj, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	var ipqueueszResp IpqueueszResp
+	if err := json.Unmarshal(resp.Data, &ipqueueszResp); err != nil {
+		return nil, err
+	}
+
+	return &ipqueueszResp, nil
+}
+
+// IpqueueszPing returns the internal producer queue state from all servers.
+func (s *System) IpqueueszPing(ctx context.Context, opts IpqueueszEventOptions) ([]IpqueueszResp, error) {
+	subj := fmt.Sprintf(srvIpqueueszSubj, "PING")
+	payload, err := json.Marshal(opts)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.pingServers(ctx, subj, payload)
+	if err != nil {
+		return nil, err
+	}
+	srvIpqueuesz := make([]IpqueueszResp, 0, len(resp))
+	for _, msg := range resp {
+		var ipqueueszResp IpqueueszResp
+		if err := json.Unmarshal(msg.Data, &ipqueueszResp); err != nil {
+			return nil, err
+		}
+		srvIpqueuesz = append(srvIpqueuesz, ipqueueszResp)
+	}
+	return srvIpqueuesz, nil
+}

--- a/natssysclient/leafz.go
+++ b/natssysclient/leafz.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Synadia Communications Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package natssysclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+type (
+	// LeafzResp is the response from a Leafz request.
+	LeafzResp struct {
+		Server ServerInfo `json:"server"`
+		Leafz  Leafz      `json:"data"`
+		Error  APIError   `json:"error,omitempty"`
+	}
+
+	// Leafz represents detailed information on leaf node connections.
+	Leafz struct {
+		ID       string      `json:"server_id"`
+		Now      time.Time   `json:"now"`
+		NumLeafs int         `json:"leafnodes"`
+		Leafs    []*LeafInfo `json:"leafs"`
+	}
+
+	// LeafInfo has detailed information on a remote leafnode connection.
+	LeafInfo struct {
+		ID          uint64     `json:"id"`
+		Name        string     `json:"name"`
+		IsSpoke     bool       `json:"is_spoke"`
+		IsIsolated  bool       `json:"is_isolated,omitempty"`
+		Account     string     `json:"account"`
+		IP          string     `json:"ip"`
+		Port        int        `json:"port"`
+		RTT         string     `json:"rtt,omitempty"`
+		InMsgs      int64      `json:"in_msgs"`
+		OutMsgs     int64      `json:"out_msgs"`
+		InBytes     int64      `json:"in_bytes"`
+		OutBytes    int64      `json:"out_bytes"`
+		NumSubs     uint32     `json:"subscriptions"`
+		Subs        []string   `json:"subscriptions_list,omitempty"`
+		Compression string     `json:"compression,omitempty"`
+		Proxy       *ProxyInfo `json:"proxy,omitempty"`
+	}
+
+	// ProxyInfo represents information about a proxied connection.
+	ProxyInfo struct {
+		Key string `json:"key"`
+	}
+
+	// LeafzOptions are options passed to Leafz.
+	LeafzOptions struct {
+		// Subscriptions indicates that Leafz will return a leafnode's subscriptions.
+		Subscriptions bool `json:"subscriptions"`
+		// Account filters the list to leafnodes serving a specific account.
+		Account string `json:"account"`
+	}
+
+	// LeafzEventOptions are the options passed to Leafz requests issued over the system events subject.
+	LeafzEventOptions struct {
+		LeafzOptions
+		EventFilterOptions
+	}
+)
+
+// Leafz returns leafnode connection details from a specific server.
+func (s *System) Leafz(ctx context.Context, id string, opts LeafzEventOptions) (*LeafzResp, error) {
+	payload, err := json.Marshal(opts)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.requestByID(ctx, id, srvLeafzSubj, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	var leafzResp LeafzResp
+	if err := json.Unmarshal(resp.Data, &leafzResp); err != nil {
+		return nil, err
+	}
+
+	return &leafzResp, nil
+}
+
+// LeafzPing returns leafnode connection details from all servers.
+func (s *System) LeafzPing(ctx context.Context, opts LeafzEventOptions) ([]LeafzResp, error) {
+	subj := fmt.Sprintf(srvLeafzSubj, "PING")
+	payload, err := json.Marshal(opts)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.pingServers(ctx, subj, payload)
+	if err != nil {
+		return nil, err
+	}
+	srvLeafz := make([]LeafzResp, 0, len(resp))
+	for _, msg := range resp {
+		var leafzResp LeafzResp
+		if err := json.Unmarshal(msg.Data, &leafzResp); err != nil {
+			return nil, err
+		}
+		srvLeafz = append(srvLeafz, leafzResp)
+	}
+	return srvLeafz, nil
+}

--- a/natssysclient/profilez.go
+++ b/natssysclient/profilez.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Synadia Communications Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package natssysclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+type (
+	// ProfilezResp is the response from a Profilez request.
+	ProfilezResp struct {
+		Server   ServerInfo     `json:"server"`
+		Profilez ProfilezStatus `json:"data"`
+		Error    APIError       `json:"error,omitempty"`
+	}
+
+	// ProfilezStatus contains a runtime profile produced by the server.
+	ProfilezStatus struct {
+		Profile []byte `json:"profile"`
+		Error   string `json:"error"`
+	}
+
+	// ProfilezOptions are the options passed to Profilez.
+	ProfilezOptions struct {
+		// Name is the profile name to collect (e.g. "cpu", "heap", "goroutine", "allocs").
+		Name string `json:"name"`
+		// Debug is the debug level for the profile.
+		Debug int `json:"debug"`
+		// Duration is the CPU profile duration (only used when Name is "cpu"). Must be > 0 and <= 15s.
+		Duration time.Duration `json:"duration,omitempty"`
+	}
+
+	// ProfilezEventOptions are the options passed to Profilez requests issued over the system events subject.
+	ProfilezEventOptions struct {
+		ProfilezOptions
+		EventFilterOptions
+	}
+)
+
+// Profilez returns runtime profiling data from a specific server.
+// CPU profiles cause the server to sleep on the request path for the configured Duration,
+// delaying other system-account monitoring traffic on that server until the profile completes.
+// Duration must be > 0 and <= 15s.
+func (s *System) Profilez(ctx context.Context, id string, opts ProfilezEventOptions) (*ProfilezResp, error) {
+	payload, err := json.Marshal(opts)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.requestByID(ctx, id, srvProfilezSubj, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	var profilezResp ProfilezResp
+	if err := json.Unmarshal(resp.Data, &profilezResp); err != nil {
+		return nil, err
+	}
+
+	return &profilezResp, nil
+}
+
+// ProfilezPing returns runtime profiling data from all servers.
+// CPU profiles cause each server to sleep on the request path for the configured Duration
+// (fanned out across the cluster, this can meaningfully delay monitoring traffic).
+func (s *System) ProfilezPing(ctx context.Context, opts ProfilezEventOptions) ([]ProfilezResp, error) {
+	subj := fmt.Sprintf(srvProfilezSubj, "PING")
+	payload, err := json.Marshal(opts)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.pingServers(ctx, subj, payload)
+	if err != nil {
+		return nil, err
+	}
+	srvProfilez := make([]ProfilezResp, 0, len(resp))
+	for _, msg := range resp {
+		var profilezResp ProfilezResp
+		if err := json.Unmarshal(msg.Data, &profilezResp); err != nil {
+			return nil, err
+		}
+		srvProfilez = append(srvProfilez, profilezResp)
+	}
+	return srvProfilez, nil
+}

--- a/natssysclient/raftz.go
+++ b/natssysclient/raftz.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Synadia Communications Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package natssysclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+type (
+	// RaftzResp is the response from a Raftz request.
+	RaftzResp struct {
+		Server ServerInfo  `json:"server"`
+		Raftz  RaftzStatus `json:"data"`
+		Error  APIError    `json:"error,omitempty"`
+	}
+
+	// RaftzStatus maps account names to their Raft groups.
+	RaftzStatus map[string]map[string]RaftzGroup
+
+	// RaftzGroup contains state for a single Raft group.
+	RaftzGroup struct {
+		ID            string                    `json:"id"`
+		State         string                    `json:"state"`
+		Size          int                       `json:"size"`
+		QuorumNeeded  int                       `json:"quorum_needed"`
+		Observer      bool                      `json:"observer,omitempty"`
+		Paused        bool                      `json:"paused,omitempty"`
+		Committed     uint64                    `json:"committed"`
+		Applied       uint64                    `json:"applied"`
+		CatchingUp    bool                      `json:"catching_up,omitempty"`
+		Leader        string                    `json:"leader,omitempty"`
+		LeaderSince   *time.Time                `json:"leader_since,omitempty"`
+		EverHadLeader bool                      `json:"ever_had_leader"`
+		Term          uint64                    `json:"term"`
+		Vote          string                    `json:"voted_for,omitempty"`
+		PTerm         uint64                    `json:"pterm"`
+		PIndex        uint64                    `json:"pindex"`
+		SystemAcc     bool                      `json:"system_account"`
+		TrafficAcc    string                    `json:"traffic_account"`
+		IPQPropLen    int                       `json:"ipq_proposal_len"`
+		IPQEntryLen   int                       `json:"ipq_entry_len"`
+		IPQRespLen    int                       `json:"ipq_resp_len"`
+		IPQApplyLen   int                       `json:"ipq_apply_len"`
+		WAL           nats.StreamState          `json:"wal"`
+		WALError      string                    `json:"wal_error,omitempty"`
+		Peers         map[string]RaftzGroupPeer `json:"peers"`
+	}
+
+	// RaftzGroupPeer contains state for a single peer within a Raft group.
+	RaftzGroupPeer struct {
+		Name                string `json:"name"`
+		Known               bool   `json:"known"`
+		LastReplicatedIndex uint64 `json:"last_replicated_index,omitempty"`
+		LastSeen            string `json:"last_seen,omitempty"`
+	}
+
+	// RaftzOptions are the options passed to Raftz.
+	RaftzOptions struct {
+		// AccountFilter limits the results to a single account. Defaults to the system account.
+		AccountFilter string `json:"account"`
+		// GroupFilter limits the results to a single Raft group.
+		GroupFilter string `json:"group"`
+	}
+
+	// RaftzEventOptions are the options passed to Raftz requests issued over the system events subject.
+	RaftzEventOptions struct {
+		EventFilterOptions
+		RaftzOptions
+	}
+)
+
+// Raftz returns Raft group state from a specific server.
+func (s *System) Raftz(ctx context.Context, id string, opts RaftzEventOptions) (*RaftzResp, error) {
+	payload, err := json.Marshal(opts)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.requestByID(ctx, id, srvRaftzSubj, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	var raftzResp RaftzResp
+	if err := json.Unmarshal(resp.Data, &raftzResp); err != nil {
+		return nil, err
+	}
+
+	return &raftzResp, nil
+}
+
+// RaftzPing returns Raft group state from all servers.
+func (s *System) RaftzPing(ctx context.Context, opts RaftzEventOptions) ([]RaftzResp, error) {
+	subj := fmt.Sprintf(srvRaftzSubj, "PING")
+	payload, err := json.Marshal(opts)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.pingServers(ctx, subj, payload)
+	if err != nil {
+		return nil, err
+	}
+	srvRaftz := make([]RaftzResp, 0, len(resp))
+	for _, msg := range resp {
+		var raftzResp RaftzResp
+		if err := json.Unmarshal(msg.Data, &raftzResp); err != nil {
+			return nil, err
+		}
+		srvRaftz = append(srvRaftz, raftzResp)
+	}
+	return srvRaftz, nil
+}

--- a/natssysclient/routez.go
+++ b/natssysclient/routez.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Synadia Communications Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package natssysclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+type (
+	// RoutezResp is the response from a Routez request.
+	RoutezResp struct {
+		Server ServerInfo `json:"server"`
+		Routez Routez     `json:"data"`
+		Error  APIError   `json:"error,omitempty"`
+	}
+
+	// Routez contains detailed information on current route connections.
+	Routez struct {
+		ID        string             `json:"server_id"`
+		Name      string             `json:"server_name"`
+		Now       time.Time          `json:"now"`
+		Import    *SubjectPermission `json:"import,omitempty"`
+		Export    *SubjectPermission `json:"export,omitempty"`
+		NumRoutes int                `json:"num_routes"`
+		Routes    []*RouteInfo       `json:"routes"`
+	}
+
+	// SubjectPermission represents allow/deny lists for subjects.
+	SubjectPermission struct {
+		Allow []string `json:"allow,omitempty"`
+		Deny  []string `json:"deny,omitempty"`
+	}
+
+	// RouteInfo has detailed information on a per connection basis.
+	RouteInfo struct {
+		Rid          uint64             `json:"rid"`
+		RemoteID     string             `json:"remote_id"`
+		RemoteName   string             `json:"remote_name"`
+		DidSolicit   bool               `json:"did_solicit"`
+		IsConfigured bool               `json:"is_configured"`
+		IP           string             `json:"ip"`
+		Port         int                `json:"port"`
+		Start        time.Time          `json:"start"`
+		LastActivity time.Time          `json:"last_activity"`
+		RTT          string             `json:"rtt,omitempty"`
+		Uptime       string             `json:"uptime"`
+		Idle         string             `json:"idle"`
+		Import       *SubjectPermission `json:"import,omitempty"`
+		Export       *SubjectPermission `json:"export,omitempty"`
+		Pending      int                `json:"pending_size"`
+		InMsgs       int64              `json:"in_msgs"`
+		OutMsgs      int64              `json:"out_msgs"`
+		InBytes      int64              `json:"in_bytes"`
+		OutBytes     int64              `json:"out_bytes"`
+		NumSubs      uint32             `json:"subscriptions"`
+		Subs         []string           `json:"subscriptions_list,omitempty"`
+		SubsDetail   []SubDetail        `json:"subscriptions_list_detail,omitempty"`
+		Account      string             `json:"account,omitempty"`
+		Compression  string             `json:"compression,omitempty"`
+	}
+
+	// RoutezOptions are options passed to Routez.
+	RoutezOptions struct {
+		// Subscriptions indicates that Routez will return a route's subscriptions.
+		Subscriptions bool `json:"subscriptions"`
+		// SubscriptionsDetail indicates if subscription details should be included in the results.
+		SubscriptionsDetail bool `json:"subscriptions_detail"`
+	}
+
+	// RoutezEventOptions are the options passed to Routez requests issued over the system events subject.
+	RoutezEventOptions struct {
+		RoutezOptions
+		EventFilterOptions
+	}
+)
+
+// Routez returns route connection details from a specific server.
+func (s *System) Routez(ctx context.Context, id string, opts RoutezEventOptions) (*RoutezResp, error) {
+	payload, err := json.Marshal(opts)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.requestByID(ctx, id, srvRoutezSubj, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	var routezResp RoutezResp
+	if err := json.Unmarshal(resp.Data, &routezResp); err != nil {
+		return nil, err
+	}
+
+	return &routezResp, nil
+}
+
+// RoutezPing returns route connection details from all servers.
+func (s *System) RoutezPing(ctx context.Context, opts RoutezEventOptions) ([]RoutezResp, error) {
+	subj := fmt.Sprintf(srvRoutezSubj, "PING")
+	payload, err := json.Marshal(opts)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.pingServers(ctx, subj, payload)
+	if err != nil {
+		return nil, err
+	}
+	srvRoutez := make([]RoutezResp, 0, len(resp))
+	for _, msg := range resp {
+		var routezResp RoutezResp
+		if err := json.Unmarshal(msg.Data, &routezResp); err != nil {
+			return nil, err
+		}
+		srvRoutez = append(srvRoutez, routezResp)
+	}
+	return srvRoutez, nil
+}

--- a/natssysclient/test/accountz_test.go
+++ b/natssysclient/test/accountz_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Synadia Communications Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/synadia-io/orbit.go/natssysclient"
+)
+
+func TestAccountz(t *testing.T) {
+	c := SetupCluster(t)
+	defer c.Shutdown()
+
+	var urls []string
+	for _, s := range c.servers {
+		urls = append(urls, s.ClientURL())
+	}
+
+	sysConn, err := nats.Connect(strings.Join(urls, ","), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error establishing connection: %s", err)
+	}
+
+	tests := []struct {
+		name      string
+		id        string
+		options   natssysclient.AccountzEventOptions
+		withError error
+	}{
+		{
+			name: "list accounts",
+			id:   c.servers[1].ID(),
+		},
+		{
+			name: "account detail",
+			id:   c.servers[1].ID(),
+			options: natssysclient.AccountzEventOptions{
+				AccountzOptions: natssysclient.AccountzOptions{Account: "JS"},
+			},
+		},
+		{
+			name:      "with empty id",
+			id:        "",
+			withError: natssysclient.ErrValidation,
+		},
+		{
+			name:      "with invalid id",
+			id:        "asd",
+			withError: natssysclient.ErrInvalidServerID,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sys, err := natssysclient.NewSysClient(sysConn)
+			if err != nil {
+				t.Fatalf("Error creating system client: %s", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			accountz, err := sys.Accountz(ctx, test.id, test.options)
+			if test.withError != nil {
+				if !errors.Is(err, test.withError) {
+					t.Fatalf("Expected error; want: %s; got: %s", test.withError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unable to fetch ACCOUNTZ: %s", err)
+			}
+			if accountz.Server.ID != test.id {
+				t.Fatalf("Invalid server ACCOUNTZ response: %+v", accountz)
+			}
+			if test.options.Account == "" {
+				if len(accountz.Accountz.Accounts) == 0 {
+					t.Fatalf("Expected non-empty account list")
+				}
+				return
+			}
+			if accountz.Accountz.Account == nil {
+				t.Fatalf("Expected account details in the response")
+			}
+			if accountz.Accountz.Account.AccountName != test.options.Account {
+				t.Fatalf("Invalid account name: got %q, want %q", accountz.Accountz.Account.AccountName, test.options.Account)
+			}
+			if !accountz.Accountz.Account.JetStream {
+				t.Fatalf("Expected JetStream=true for account %q", test.options.Account)
+			}
+			if accountz.Accountz.Account.IsSystem {
+				t.Fatalf("Expected IsSystem=false for account %q", test.options.Account)
+			}
+		})
+	}
+}
+
+func TestAccountzPing(t *testing.T) {
+	c := SetupCluster(t)
+	defer c.Shutdown()
+
+	var urls []string
+	for _, s := range c.servers {
+		urls = append(urls, s.ClientURL())
+	}
+
+	sysConn, err := nats.Connect(strings.Join(urls, ","), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error establishing connection: %s", err)
+	}
+
+	sys, err := natssysclient.NewSysClient(sysConn)
+	if err != nil {
+		t.Fatalf("Error creating system client: %s", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := sys.AccountzPing(ctx, natssysclient.AccountzEventOptions{})
+	if err != nil {
+		t.Fatalf("Unable to fetch ACCOUNTZ: %s", err)
+	}
+	if len(resp) != 3 {
+		t.Fatalf("Invalid number of responses: %d; want: %d", len(resp), 3)
+	}
+	for _, accountz := range resp {
+		if len(accountz.Accountz.Accounts) == 0 {
+			t.Fatalf("Expected non-empty account list for server %q", accountz.Server.ID)
+		}
+	}
+}

--- a/natssysclient/test/expvarz_test.go
+++ b/natssysclient/test/expvarz_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Synadia Communications Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/synadia-io/orbit.go/natssysclient"
+)
+
+func TestExpvarz(t *testing.T) {
+	c := SetupCluster(t)
+	defer c.Shutdown()
+
+	var urls []string
+	for _, s := range c.servers {
+		urls = append(urls, s.ClientURL())
+	}
+
+	sysConn, err := nats.Connect(strings.Join(urls, ","), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error establishing connection: %s", err)
+	}
+
+	tests := []struct {
+		name      string
+		id        string
+		withError error
+	}{
+		{
+			name: "with valid id",
+			id:   c.servers[1].ID(),
+		},
+		{
+			name:      "with empty id",
+			id:        "",
+			withError: natssysclient.ErrValidation,
+		},
+		{
+			name:      "with invalid id",
+			id:        "asd",
+			withError: natssysclient.ErrInvalidServerID,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sys, err := natssysclient.NewSysClient(sysConn)
+			if err != nil {
+				t.Fatalf("Error creating system client: %s", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			expvarz, err := sys.Expvarz(ctx, test.id, natssysclient.ExpvarzEventOptions{})
+			if test.withError != nil {
+				if !errors.Is(err, test.withError) {
+					t.Fatalf("Expected error; want: %s; got: %s", test.withError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unable to fetch EXPVARZ: %s", err)
+			}
+			if expvarz.Server.ID != test.id {
+				t.Fatalf("Invalid server EXPVARZ response: %+v", expvarz)
+			}
+			if len(expvarz.Expvarz.Memstats) == 0 {
+				t.Fatalf("Expected non-empty memstats in EXPVARZ response")
+			}
+		})
+	}
+}
+
+func TestExpvarzPing(t *testing.T) {
+	c := SetupCluster(t)
+	defer c.Shutdown()
+
+	var urls []string
+	for _, s := range c.servers {
+		urls = append(urls, s.ClientURL())
+	}
+
+	sysConn, err := nats.Connect(strings.Join(urls, ","), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error establishing connection: %s", err)
+	}
+
+	sys, err := natssysclient.NewSysClient(sysConn)
+	if err != nil {
+		t.Fatalf("Error creating system client: %s", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := sys.ExpvarzPing(ctx, natssysclient.ExpvarzEventOptions{})
+	if err != nil {
+		t.Fatalf("Unable to fetch EXPVARZ: %s", err)
+	}
+	if len(resp) != 3 {
+		t.Fatalf("Invalid number of responses: %d; want: %d", len(resp), 3)
+	}
+}

--- a/natssysclient/test/gatewayz_test.go
+++ b/natssysclient/test/gatewayz_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Synadia Communications Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/synadia-io/orbit.go/natssysclient"
+)
+
+func TestGatewayz(t *testing.T) {
+	c := SetupCluster(t)
+	defer c.Shutdown()
+
+	var urls []string
+	for _, s := range c.servers {
+		urls = append(urls, s.ClientURL())
+	}
+
+	sysConn, err := nats.Connect(strings.Join(urls, ","), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error establishing connection: %s", err)
+	}
+
+	tests := []struct {
+		name      string
+		id        string
+		withError error
+	}{
+		{
+			name: "with valid id",
+			id:   c.servers[1].ID(),
+		},
+		{
+			name:      "with empty id",
+			id:        "",
+			withError: natssysclient.ErrValidation,
+		},
+		{
+			name:      "with invalid id",
+			id:        "asd",
+			withError: natssysclient.ErrInvalidServerID,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sys, err := natssysclient.NewSysClient(sysConn)
+			if err != nil {
+				t.Fatalf("Error creating system client: %s", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			gatewayz, err := sys.Gatewayz(ctx, test.id, natssysclient.GatewayzEventOptions{})
+			if test.withError != nil {
+				if !errors.Is(err, test.withError) {
+					t.Fatalf("Expected error; want: %s; got: %s", test.withError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unable to fetch GATEWAYZ: %s", err)
+			}
+			if gatewayz.Server.ID != test.id {
+				t.Fatalf("Invalid server GATEWAYZ response: %+v", gatewayz)
+			}
+		})
+	}
+}
+
+func TestGatewayzPing(t *testing.T) {
+	c := SetupCluster(t)
+	defer c.Shutdown()
+
+	var urls []string
+	for _, s := range c.servers {
+		urls = append(urls, s.ClientURL())
+	}
+
+	sysConn, err := nats.Connect(strings.Join(urls, ","), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error establishing connection: %s", err)
+	}
+
+	sys, err := natssysclient.NewSysClient(sysConn)
+	if err != nil {
+		t.Fatalf("Error creating system client: %s", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := sys.GatewayzPing(ctx, natssysclient.GatewayzEventOptions{})
+	if err != nil {
+		t.Fatalf("Unable to fetch GATEWAYZ: %s", err)
+	}
+	if len(resp) != 3 {
+		t.Fatalf("Invalid number of responses: %d; want: %d", len(resp), 3)
+	}
+}

--- a/natssysclient/test/idz_test.go
+++ b/natssysclient/test/idz_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Synadia Communications Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/synadia-io/orbit.go/natssysclient"
+)
+
+func TestIdz(t *testing.T) {
+	c := SetupCluster(t)
+	defer c.Shutdown()
+
+	var urls []string
+	for _, s := range c.servers {
+		urls = append(urls, s.ClientURL())
+	}
+
+	sysConn, err := nats.Connect(strings.Join(urls, ","), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error establishing connection: %s", err)
+	}
+
+	tests := []struct {
+		name      string
+		id        string
+		withError error
+	}{
+		{
+			name: "with valid id",
+			id:   c.servers[1].ID(),
+		},
+		{
+			name:      "with empty id",
+			id:        "",
+			withError: natssysclient.ErrValidation,
+		},
+		{
+			name:      "with invalid id",
+			id:        "asd",
+			withError: natssysclient.ErrInvalidServerID,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sys, err := natssysclient.NewSysClient(sysConn)
+			if err != nil {
+				t.Fatalf("Error creating system client: %s", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			idz, err := sys.Idz(ctx, test.id)
+			if test.withError != nil {
+				if !errors.Is(err, test.withError) {
+					t.Fatalf("Expected error; want: %s; got: %s", test.withError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unable to fetch IDZ: %s", err)
+			}
+			if idz.ID != test.id {
+				t.Fatalf("Invalid server ID in IDZ response: got %q, want %q", idz.ID, test.id)
+			}
+			if idz.Name == "" {
+				t.Fatalf("Expected non-empty server name in IDZ response")
+			}
+		})
+	}
+}
+
+func TestIdzPing(t *testing.T) {
+	c := SetupCluster(t)
+	defer c.Shutdown()
+
+	var urls []string
+	for _, s := range c.servers {
+		urls = append(urls, s.ClientURL())
+	}
+
+	sysConn, err := nats.Connect(strings.Join(urls, ","), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error establishing connection: %s", err)
+	}
+
+	sys, err := natssysclient.NewSysClient(sysConn)
+	if err != nil {
+		t.Fatalf("Error creating system client: %s", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := sys.IdzPing(ctx)
+	if err != nil {
+		t.Fatalf("Unable to fetch IDZ: %s", err)
+	}
+	if len(resp) != 3 {
+		t.Fatalf("Invalid number of responses: %d; want: %d", len(resp), 3)
+	}
+	seen := map[string]bool{}
+	for _, idz := range resp {
+		seen[idz.ID] = true
+	}
+	for _, s := range c.servers {
+		if !seen[s.ID()] {
+			t.Fatalf("Expected server %q in the response", s.Name())
+		}
+	}
+}

--- a/natssysclient/test/ipqueuesz_test.go
+++ b/natssysclient/test/ipqueuesz_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 Synadia Communications Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/synadia-io/orbit.go/natssysclient"
+)
+
+func TestIpqueuesz(t *testing.T) {
+	c := SetupCluster(t)
+	defer c.Shutdown()
+
+	var urls []string
+	for _, s := range c.servers {
+		urls = append(urls, s.ClientURL())
+	}
+
+	sysConn, err := nats.Connect(strings.Join(urls, ","), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error establishing connection: %s", err)
+	}
+
+	tests := []struct {
+		name      string
+		id        string
+		options   natssysclient.IpqueueszEventOptions
+		withError error
+	}{
+		{
+			name: "with valid id",
+			id:   c.servers[1].ID(),
+			options: natssysclient.IpqueueszEventOptions{
+				IpqueueszOptions: natssysclient.IpqueueszOptions{All: true},
+			},
+		},
+		{
+			name:      "with empty id",
+			id:        "",
+			withError: natssysclient.ErrValidation,
+		},
+		{
+			name:      "with invalid id",
+			id:        "asd",
+			withError: natssysclient.ErrInvalidServerID,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sys, err := natssysclient.NewSysClient(sysConn)
+			if err != nil {
+				t.Fatalf("Error creating system client: %s", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			ipqueuesz, err := sys.Ipqueuesz(ctx, test.id, test.options)
+			if test.withError != nil {
+				if !errors.Is(err, test.withError) {
+					t.Fatalf("Expected error; want: %s; got: %s", test.withError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unable to fetch IPQUEUESZ: %s", err)
+			}
+			if ipqueuesz.Server.ID != test.id {
+				t.Fatalf("Invalid server IPQUEUESZ response: %+v", ipqueuesz)
+			}
+			if len(ipqueuesz.Ipqueuesz) == 0 {
+				t.Fatalf("Expected at least one internal queue when All=true")
+			}
+		})
+	}
+}
+
+func TestIpqueueszFilter(t *testing.T) {
+	c := SetupCluster(t)
+	defer c.Shutdown()
+
+	var urls []string
+	for _, s := range c.servers {
+		urls = append(urls, s.ClientURL())
+	}
+
+	sysConn, err := nats.Connect(strings.Join(urls, ","), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error establishing connection: %s", err)
+	}
+
+	sys, err := natssysclient.NewSysClient(sysConn)
+	if err != nil {
+		t.Fatalf("Error creating system client: %s", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	serverID := c.servers[1].ID()
+
+	all, err := sys.Ipqueuesz(ctx, serverID, natssysclient.IpqueueszEventOptions{
+		IpqueueszOptions: natssysclient.IpqueueszOptions{All: true},
+	})
+	if err != nil {
+		t.Fatalf("Unable to fetch IPQUEUESZ: %s", err)
+	}
+	if len(all.Ipqueuesz) == 0 {
+		t.Fatalf("Expected at least one queue when All=true")
+	}
+
+	var probe string
+	for name := range all.Ipqueuesz {
+		probe = name
+		break
+	}
+	if len(probe) < 2 {
+		t.Fatalf("Unexpected queue name %q used as filter probe", probe)
+	}
+	fragment := probe[:len(probe)/2]
+
+	filtered, err := sys.Ipqueuesz(ctx, serverID, natssysclient.IpqueueszEventOptions{
+		IpqueueszOptions: natssysclient.IpqueueszOptions{All: true, Filter: fragment},
+	})
+	if err != nil {
+		t.Fatalf("Unable to fetch filtered IPQUEUESZ: %s", err)
+	}
+	if len(filtered.Ipqueuesz) == 0 {
+		t.Fatalf("Expected at least one queue matching filter %q", fragment)
+	}
+	if len(filtered.Ipqueuesz) > len(all.Ipqueuesz) {
+		t.Fatalf("Filtered result (%d) must not exceed unfiltered (%d)", len(filtered.Ipqueuesz), len(all.Ipqueuesz))
+	}
+	for name := range filtered.Ipqueuesz {
+		if !strings.Contains(name, fragment) {
+			t.Fatalf("Queue %q does not contain filter fragment %q", name, fragment)
+		}
+	}
+}
+
+func TestIpqueueszPing(t *testing.T) {
+	c := SetupCluster(t)
+	defer c.Shutdown()
+
+	var urls []string
+	for _, s := range c.servers {
+		urls = append(urls, s.ClientURL())
+	}
+
+	sysConn, err := nats.Connect(strings.Join(urls, ","), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error establishing connection: %s", err)
+	}
+
+	sys, err := natssysclient.NewSysClient(sysConn)
+	if err != nil {
+		t.Fatalf("Error creating system client: %s", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := sys.IpqueueszPing(ctx, natssysclient.IpqueueszEventOptions{
+		IpqueueszOptions: natssysclient.IpqueueszOptions{All: true},
+	})
+	if err != nil {
+		t.Fatalf("Unable to fetch IPQUEUESZ: %s", err)
+	}
+	if len(resp) != 3 {
+		t.Fatalf("Invalid number of responses: %d; want: %d", len(resp), 3)
+	}
+	for _, ipq := range resp {
+		if len(ipq.Ipqueuesz) == 0 {
+			t.Fatalf("Expected at least one internal queue for server %q", ipq.Server.ID)
+		}
+	}
+}

--- a/natssysclient/test/leafz_test.go
+++ b/natssysclient/test/leafz_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Synadia Communications Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/synadia-io/orbit.go/natssysclient"
+)
+
+func TestLeafz(t *testing.T) {
+	c := SetupCluster(t)
+	defer c.Shutdown()
+
+	var urls []string
+	for _, s := range c.servers {
+		urls = append(urls, s.ClientURL())
+	}
+
+	sysConn, err := nats.Connect(strings.Join(urls, ","), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error establishing connection: %s", err)
+	}
+
+	tests := []struct {
+		name      string
+		id        string
+		withError error
+	}{
+		{
+			name: "with valid id",
+			id:   c.servers[1].ID(),
+		},
+		{
+			name:      "with empty id",
+			id:        "",
+			withError: natssysclient.ErrValidation,
+		},
+		{
+			name:      "with invalid id",
+			id:        "asd",
+			withError: natssysclient.ErrInvalidServerID,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sys, err := natssysclient.NewSysClient(sysConn)
+			if err != nil {
+				t.Fatalf("Error creating system client: %s", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			leafz, err := sys.Leafz(ctx, test.id, natssysclient.LeafzEventOptions{})
+			if test.withError != nil {
+				if !errors.Is(err, test.withError) {
+					t.Fatalf("Expected error; want: %s; got: %s", test.withError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unable to fetch LEAFZ: %s", err)
+			}
+			if leafz.Server.ID != test.id {
+				t.Fatalf("Invalid server LEAFZ response: %+v", leafz)
+			}
+		})
+	}
+}
+
+func TestLeafzPing(t *testing.T) {
+	c := SetupCluster(t)
+	defer c.Shutdown()
+
+	var urls []string
+	for _, s := range c.servers {
+		urls = append(urls, s.ClientURL())
+	}
+
+	sysConn, err := nats.Connect(strings.Join(urls, ","), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error establishing connection: %s", err)
+	}
+
+	sys, err := natssysclient.NewSysClient(sysConn)
+	if err != nil {
+		t.Fatalf("Error creating system client: %s", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := sys.LeafzPing(ctx, natssysclient.LeafzEventOptions{})
+	if err != nil {
+		t.Fatalf("Unable to fetch LEAFZ: %s", err)
+	}
+	if len(resp) != 3 {
+		t.Fatalf("Invalid number of responses: %d; want: %d", len(resp), 3)
+	}
+}

--- a/natssysclient/test/profilez_test.go
+++ b/natssysclient/test/profilez_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Synadia Communications Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/synadia-io/orbit.go/natssysclient"
+)
+
+func TestProfilez(t *testing.T) {
+	c := SetupCluster(t)
+	defer c.Shutdown()
+
+	var urls []string
+	for _, s := range c.servers {
+		urls = append(urls, s.ClientURL())
+	}
+
+	sysConn, err := nats.Connect(strings.Join(urls, ","), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error establishing connection: %s", err)
+	}
+
+	tests := []struct {
+		name      string
+		id        string
+		options   natssysclient.ProfilezEventOptions
+		withError error
+	}{
+		{
+			name: "heap profile",
+			id:   c.servers[1].ID(),
+			options: natssysclient.ProfilezEventOptions{
+				ProfilezOptions: natssysclient.ProfilezOptions{Name: "heap"},
+			},
+		},
+		{
+			name: "goroutine profile",
+			id:   c.servers[1].ID(),
+			options: natssysclient.ProfilezEventOptions{
+				ProfilezOptions: natssysclient.ProfilezOptions{Name: "goroutine", Debug: 1},
+			},
+		},
+		{
+			name:      "with empty id",
+			id:        "",
+			options:   natssysclient.ProfilezEventOptions{ProfilezOptions: natssysclient.ProfilezOptions{Name: "heap"}},
+			withError: natssysclient.ErrValidation,
+		},
+		{
+			name:      "with invalid id",
+			id:        "asd",
+			options:   natssysclient.ProfilezEventOptions{ProfilezOptions: natssysclient.ProfilezOptions{Name: "heap"}},
+			withError: natssysclient.ErrInvalidServerID,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sys, err := natssysclient.NewSysClient(sysConn)
+			if err != nil {
+				t.Fatalf("Error creating system client: %s", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			profilez, err := sys.Profilez(ctx, test.id, test.options)
+			if test.withError != nil {
+				if !errors.Is(err, test.withError) {
+					t.Fatalf("Expected error; want: %s; got: %s", test.withError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unable to fetch PROFILEZ: %s", err)
+			}
+			if profilez.Server.ID != test.id {
+				t.Fatalf("Invalid server PROFILEZ response: %+v", profilez)
+			}
+			if profilez.Profilez.Error != "" {
+				t.Fatalf("Profilez returned error: %s", profilez.Profilez.Error)
+			}
+			if len(profilez.Profilez.Profile) == 0 {
+				t.Fatalf("Expected non-empty profile data")
+			}
+		})
+	}
+}
+
+func TestProfilezCPU(t *testing.T) {
+	c := SetupCluster(t)
+	defer c.Shutdown()
+
+	var urls []string
+	for _, s := range c.servers {
+		urls = append(urls, s.ClientURL())
+	}
+
+	sysConn, err := nats.Connect(strings.Join(urls, ","), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error establishing connection: %s", err)
+	}
+
+	sys, err := natssysclient.NewSysClient(sysConn)
+	if err != nil {
+		t.Fatalf("Error creating system client: %s", err)
+	}
+
+	// CPU profile forces the server to sleep on the request path for Duration; budget generously.
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	profilez, err := sys.Profilez(ctx, c.servers[1].ID(), natssysclient.ProfilezEventOptions{
+		ProfilezOptions: natssysclient.ProfilezOptions{Name: "cpu", Duration: 500 * time.Millisecond},
+	})
+	if err != nil {
+		t.Fatalf("Unable to fetch PROFILEZ: %s", err)
+	}
+	elapsed := time.Since(start)
+
+	if elapsed < 500*time.Millisecond {
+		t.Fatalf("CPU profile returned too fast (%s); expected at least Duration to elapse", elapsed)
+	}
+	if profilez.Profilez.Error != "" {
+		t.Fatalf("Profilez returned error: %s", profilez.Profilez.Error)
+	}
+	if len(profilez.Profilez.Profile) == 0 {
+		t.Fatalf("Expected non-empty CPU profile data")
+	}
+}
+
+func TestProfilezPing(t *testing.T) {
+	c := SetupCluster(t)
+	defer c.Shutdown()
+
+	var urls []string
+	for _, s := range c.servers {
+		urls = append(urls, s.ClientURL())
+	}
+
+	sysConn, err := nats.Connect(strings.Join(urls, ","), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error establishing connection: %s", err)
+	}
+
+	sys, err := natssysclient.NewSysClient(sysConn)
+	if err != nil {
+		t.Fatalf("Error creating system client: %s", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	resp, err := sys.ProfilezPing(ctx, natssysclient.ProfilezEventOptions{
+		ProfilezOptions: natssysclient.ProfilezOptions{Name: "heap"},
+	})
+	if err != nil {
+		t.Fatalf("Unable to fetch PROFILEZ: %s", err)
+	}
+	if len(resp) != 3 {
+		t.Fatalf("Invalid number of responses: %d; want: %d", len(resp), 3)
+	}
+	for _, profilez := range resp {
+		if profilez.Profilez.Error != "" {
+			t.Fatalf("Profilez error for server %q: %s", profilez.Server.ID, profilez.Profilez.Error)
+		}
+		if len(profilez.Profilez.Profile) == 0 {
+			t.Fatalf("Expected non-empty profile data for server %q", profilez.Server.ID)
+		}
+	}
+}

--- a/natssysclient/test/raftz_test.go
+++ b/natssysclient/test/raftz_test.go
@@ -1,0 +1,189 @@
+// Copyright 2026 Synadia Communications Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/synadia-io/orbit.go/natssysclient"
+)
+
+func TestRaftz(t *testing.T) {
+	c := SetupCluster(t)
+	defer c.Shutdown()
+
+	var urls []string
+	for _, s := range c.servers {
+		urls = append(urls, s.ClientURL())
+	}
+
+	sysConn, err := nats.Connect(strings.Join(urls, ","), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error establishing connection: %s", err)
+	}
+
+	tests := []struct {
+		name      string
+		id        string
+		withError error
+	}{
+		{
+			name: "with valid id",
+			id:   c.servers[1].ID(),
+		},
+		{
+			name:      "with empty id",
+			id:        "",
+			withError: natssysclient.ErrValidation,
+		},
+		{
+			name:      "with invalid id",
+			id:        "asd",
+			withError: natssysclient.ErrInvalidServerID,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sys, err := natssysclient.NewSysClient(sysConn)
+			if err != nil {
+				t.Fatalf("Error creating system client: %s", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			raftz, err := sys.Raftz(ctx, test.id, natssysclient.RaftzEventOptions{})
+			if test.withError != nil {
+				if !errors.Is(err, test.withError) {
+					t.Fatalf("Expected error; want: %s; got: %s", test.withError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unable to fetch RAFTZ: %s", err)
+			}
+			if raftz.Server.ID != test.id {
+				t.Fatalf("Invalid server RAFTZ response: %+v", raftz)
+			}
+			if len(raftz.Raftz) == 0 {
+				t.Fatalf("Expected at least one Raft group in a JetStream cluster")
+			}
+		})
+	}
+}
+
+func TestRaftzAccountFilter(t *testing.T) {
+	c := SetupCluster(t)
+	defer c.Shutdown()
+
+	var urls []string
+	for _, s := range c.servers {
+		urls = append(urls, s.ClientURL())
+	}
+
+	sysConn, err := nats.Connect(strings.Join(urls, ","), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error establishing connection: %s", err)
+	}
+
+	// Create a replicated stream in the JS account so it owns at least one raft group.
+	jsConn, err := nats.Connect(strings.Join(urls, ","))
+	if err != nil {
+		t.Fatalf("Error connecting JS client: %s", err)
+	}
+	defer jsConn.Close()
+	js, err := jsConn.JetStream()
+	if err != nil {
+		t.Fatalf("Error getting JetStream context: %v", err)
+	}
+	if _, err := js.AddStream(&nats.StreamConfig{Name: "raftz_test", Subjects: []string{"raftz.test"}, Replicas: 3}); err != nil {
+		t.Fatalf("Error creating stream: %v", err)
+	}
+
+	sys, err := natssysclient.NewSysClient(sysConn)
+	if err != nil {
+		t.Fatalf("Error creating system client: %s", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Wait for the stream's raft group to appear in RAFTZ for the JS account.
+	deadline := time.Now().Add(5 * time.Second)
+	var filtered *natssysclient.RaftzResp
+	for time.Now().Before(deadline) {
+		filtered, err = sys.Raftz(ctx, c.servers[0].ID(), natssysclient.RaftzEventOptions{
+			RaftzOptions: natssysclient.RaftzOptions{AccountFilter: "JS"},
+		})
+		if err != nil {
+			t.Fatalf("Unable to fetch RAFTZ: %s", err)
+		}
+		if len(filtered.Raftz["JS"]) > 0 {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	if len(filtered.Raftz) == 0 {
+		t.Fatalf("Expected at least one account key with AccountFilter=JS, got none")
+	}
+	for acct := range filtered.Raftz {
+		if acct != "JS" {
+			t.Fatalf("AccountFilter=JS returned entry for account %q", acct)
+		}
+	}
+	if len(filtered.Raftz["JS"]) == 0 {
+		t.Fatalf("Expected at least one raft group in JS account after creating a replicated stream")
+	}
+}
+
+func TestRaftzPing(t *testing.T) {
+	c := SetupCluster(t)
+	defer c.Shutdown()
+
+	var urls []string
+	for _, s := range c.servers {
+		urls = append(urls, s.ClientURL())
+	}
+
+	sysConn, err := nats.Connect(strings.Join(urls, ","), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error establishing connection: %s", err)
+	}
+
+	sys, err := natssysclient.NewSysClient(sysConn)
+	if err != nil {
+		t.Fatalf("Error creating system client: %s", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	resp, err := sys.RaftzPing(ctx, natssysclient.RaftzEventOptions{})
+	if err != nil {
+		t.Fatalf("Unable to fetch RAFTZ: %s", err)
+	}
+	if len(resp) != 3 {
+		t.Fatalf("Invalid number of responses: %d; want: %d", len(resp), 3)
+	}
+	for _, raftz := range resp {
+		if len(raftz.Raftz) == 0 {
+			t.Fatalf("Expected at least one Raft group for server %q", raftz.Server.ID)
+		}
+	}
+}

--- a/natssysclient/test/routez_test.go
+++ b/natssysclient/test/routez_test.go
@@ -1,0 +1,190 @@
+// Copyright 2026 Synadia Communications Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/synadia-io/orbit.go/natssysclient"
+)
+
+func TestRoutez(t *testing.T) {
+	c := SetupCluster(t)
+	defer c.Shutdown()
+
+	var urls []string
+	for _, s := range c.servers {
+		urls = append(urls, s.ClientURL())
+	}
+
+	sysConn, err := nats.Connect(strings.Join(urls, ","), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error establishing connection: %s", err)
+	}
+
+	tests := []struct {
+		name      string
+		id        string
+		withError error
+	}{
+		{
+			name: "with valid id",
+			id:   c.servers[1].ID(),
+		},
+		{
+			name:      "with empty id",
+			id:        "",
+			withError: natssysclient.ErrValidation,
+		},
+		{
+			name:      "with invalid id",
+			id:        "asd",
+			withError: natssysclient.ErrInvalidServerID,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sys, err := natssysclient.NewSysClient(sysConn)
+			if err != nil {
+				t.Fatalf("Error creating system client: %s", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			routez, err := sys.Routez(ctx, test.id, natssysclient.RoutezEventOptions{})
+			if test.withError != nil {
+				if !errors.Is(err, test.withError) {
+					t.Fatalf("Expected error; want: %s; got: %s", test.withError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unable to fetch ROUTEZ: %s", err)
+			}
+			if routez.Server.ID != test.id {
+				t.Fatalf("Invalid server ROUTEZ response: %+v", routez)
+			}
+			if routez.Routez.NumRoutes == 0 {
+				t.Fatalf("Expected at least one route in a 3-node cluster")
+			}
+		})
+	}
+}
+
+func TestRoutezSubscriptions(t *testing.T) {
+	c := SetupCluster(t)
+	defer c.Shutdown()
+
+	var urls []string
+	for _, s := range c.servers {
+		urls = append(urls, s.ClientURL())
+	}
+
+	sysConn, err := nats.Connect(strings.Join(urls, ","), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error establishing connection: %s", err)
+	}
+
+	// A client subscription on any server should propagate to peers via the route protocol;
+	// asking a peer server for ROUTEZ with Subscriptions: true should then surface that subject
+	// in at least one of its route records.
+	nc, err := nats.Connect(c.servers[0].ClientURL())
+	if err != nil {
+		t.Fatalf("Error connecting client: %s", err)
+	}
+	defer nc.Close()
+
+	const subject = "test.routez.subs"
+	if _, err := nc.SubscribeSync(subject); err != nil {
+		t.Fatalf("Error subscribing: %s", err)
+	}
+	if err := nc.Flush(); err != nil {
+		t.Fatalf("Error flushing: %s", err)
+	}
+
+	sys, err := natssysclient.NewSysClient(sysConn)
+	if err != nil {
+		t.Fatalf("Error creating system client: %s", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	deadline := time.Now().Add(5 * time.Second)
+	var found bool
+	for time.Now().Before(deadline) {
+		routez, err := sys.Routez(ctx, c.servers[1].ID(), natssysclient.RoutezEventOptions{
+			RoutezOptions: natssysclient.RoutezOptions{Subscriptions: true},
+		})
+		if err != nil {
+			t.Fatalf("Unable to fetch ROUTEZ: %s", err)
+		}
+		for _, route := range routez.Routez.Routes {
+			if slices.Contains(route.Subs, subject) {
+				found = true
+				break
+			}
+		}
+		if found {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if !found {
+		t.Fatalf("Expected subject %q to appear in a route's Subs after propagation", subject)
+	}
+}
+
+func TestRoutezPing(t *testing.T) {
+	c := SetupCluster(t)
+	defer c.Shutdown()
+
+	var urls []string
+	for _, s := range c.servers {
+		urls = append(urls, s.ClientURL())
+	}
+
+	sysConn, err := nats.Connect(strings.Join(urls, ","), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error establishing connection: %s", err)
+	}
+
+	sys, err := natssysclient.NewSysClient(sysConn)
+	if err != nil {
+		t.Fatalf("Error creating system client: %s", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := sys.RoutezPing(ctx, natssysclient.RoutezEventOptions{})
+	if err != nil {
+		t.Fatalf("Unable to fetch ROUTEZ: %s", err)
+	}
+	if len(resp) != 3 {
+		t.Fatalf("Invalid number of responses: %d; want: %d", len(resp), 3)
+	}
+	for _, routez := range resp {
+		if routez.Routez.NumRoutes == 0 {
+			t.Fatalf("Expected at least one route per server in a 3-node cluster")
+		}
+	}
+}


### PR DESCRIPTION
Adds clients for missing SRV monitoring endpoints the library didn't previously cover, each exposed with a single-server method and a cluster-wide `*Ping` method

- `Idz` / `IdzPing`
- `Routez` / `RoutezPing`
- `Gatewayz` / `GatewayzPing`
- `Leafz` / `LeafzPing`
- `Accountz` / `AccountzPing`
- `Profilez` / `ProfilezPing`
- `Expvarz` / `ExpvarzPing`
- `Ipqueuesz` / `IpqueueszPing`
- `Raftz` / `RaftzPing`

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)