### PR TITLE
jetstreamext: fix FastPublisher stall, timeout, and reply prefix bugs 

### DIFF
--- a/jetstreamext/fastpublish.go
+++ b/jetstreamext/fastpublish.go
@@ -215,6 +215,8 @@ func (fp *fastPublisher) sendPing() error {
 
 // waitForStall blocks until the stall channel is signaled, sending periodic
 // pings to recover lost acks. Returns an error only on total timeout.
+// The deadline is intentionally shared across all re-stall cycles: ackTimeout is a
+// hard ceiling on total wait time, not per-ack wait time.
 // Must be called WITHOUT holding fp.mu.
 func (fp *fastPublisher) waitForStall(stallCh <-chan struct{}) error {
 	// Split timeout into intervals: try up to 2 pings before giving up.
@@ -227,6 +229,13 @@ func (fp *fastPublisher) waitForStall(stallCh <-chan struct{}) error {
 	for {
 		select {
 		case <-stallCh:
+			// After receiving a new ack, it could be we still need to wait more if we're being slowed down.
+			fp.mu.Lock()
+			waitForAck := fp.waitForAck()
+			fp.mu.Unlock()
+			if waitForAck {
+				continue
+			}
 			return nil
 		case <-ping.C:
 			if err := fp.sendPing(); err != nil {
@@ -295,6 +304,7 @@ func (fp *fastPublisher) AddMsg(msg *nats.Msg, opts ...BatchMsgOpt) (*FastPubAck
 		fp.firstAckCh = firstAckCh
 		initialErrCh := make(chan error, 1)
 		fp.initialErrCh = initialErrCh
+		fp.stallCh = make(chan struct{}, 1)
 
 		// Publish with reply inbox already set (without holding lock)
 		if err := fp.js.Conn().PublishMsg(msg); err != nil {
@@ -317,7 +327,6 @@ func (fp *fastPublisher) AddMsg(msg *nats.Msg, opts ...BatchMsgOpt) (*FastPubAck
 			fp.mu.Lock()
 			defer fp.mu.Unlock()
 
-			fp.flow = firstAck.Messages
 			fp.batchSubject = msg.Subject
 			return &FastPubAck{
 				BatchSequence: fp.sequence,
@@ -355,11 +364,7 @@ func (fp *fastPublisher) AddMsg(msg *nats.Msg, opts ...BatchMsgOpt) (*FastPubAck
 		return nil, fmt.Errorf("batch message %d publish failed: %w", seq, err)
 	}
 
-	waitForAck := fp.ackSequence+uint64(fp.flow)*uint64(fp.opts.maxOutstandingAcks) <= fp.sequence
-	if waitForAck {
-		if fp.stallCh == nil {
-			fp.stallCh = make(chan struct{}, 1)
-		}
+	if fp.waitForAck() {
 		stallCh := fp.stallCh
 		fp.mu.Unlock()
 		if err := fp.waitForStall(stallCh); err != nil {
@@ -378,6 +383,11 @@ func (fp *fastPublisher) AddMsg(msg *nats.Msg, opts ...BatchMsgOpt) (*FastPubAck
 		BatchSequence: seq,
 		AckSequence:   ackSeq,
 	}, nil
+}
+
+// Lock should be held.
+func (fp *fastPublisher) waitForAck() bool {
+	return fp.ackSequence+uint64(fp.flow)*uint64(fp.opts.maxOutstandingAcks) <= fp.sequence
 }
 
 // applyBatchMsgOpts processes batch message options and sets the appropriate
@@ -584,10 +594,9 @@ func (fp *fastPublisher) ackMsgHandler(msg *nats.Msg) {
 
 			// Handle flow ack. We want to let the publisher know if we are no longer stalled
 			// and can continue publishing.
-			if fp.stallCh != nil {
-				// Unblock publisher if we were stalled and are now below the max outstanding acks
-				close(fp.stallCh)
-				fp.stallCh = nil
+			select {
+			case fp.stallCh <- struct{}{}:
+			default:
 			}
 		}
 	case bytes.Contains(msg.Data, []byte(`"type":"err"`)):

--- a/jetstreamext/fastpublish.go
+++ b/jetstreamext/fastpublish.go
@@ -219,11 +219,8 @@ func (fp *fastPublisher) sendPing() error {
 // hard ceiling on total wait time, not per-ack wait time.
 // Must be called WITHOUT holding fp.mu.
 func (fp *fastPublisher) waitForStall(stallCh <-chan struct{}) error {
-	// Split timeout into intervals: try up to 2 pings before giving up.
-	pingInterval := fp.opts.ackTimeout / 3
-	deadline := time.NewTimer(fp.opts.ackTimeout)
+	deadline, ping, pingInterval := fp.newPingTimers()
 	defer deadline.Stop()
-	ping := time.NewTimer(pingInterval)
 	defer ping.Stop()
 
 	for {
@@ -246,6 +243,14 @@ func (fp *fastPublisher) waitForStall(stallCh <-chan struct{}) error {
 			return errors.New("ack timeout")
 		}
 	}
+}
+
+func (fp *fastPublisher) newPingTimers() (deadline, ping *time.Timer, pingInterval time.Duration) {
+	// wait for commit ack with periodic pings to recover lost acks, or deadline/context cancel
+	pingInterval = fp.opts.ackTimeout / 3
+	deadline = time.NewTimer(fp.opts.ackTimeout)
+	ping = time.NewTimer(pingInterval)
+	return
 }
 
 // buildReplySubject constructs the full reply subject using the cached prefix.
@@ -474,48 +479,46 @@ func (fp *fastPublisher) commit(ctx context.Context, msg *nats.Msg, eob bool) (*
 		fp.mu.Unlock()
 		return nil, fmt.Errorf("batch commit failed: %w", err)
 	}
-	waitForAck := fp.ackSequence+uint64(fp.flow)*uint64(fp.opts.maxOutstandingAcks) <= fp.sequence
-	if waitForAck {
-		if fp.stallCh == nil {
-			fp.stallCh = make(chan struct{}, 1)
-		}
-		stallCh := fp.stallCh
-		fp.mu.Unlock()
-		if err := fp.waitForStall(stallCh); err != nil {
-			fp.mu.Lock()
-			fp.closed = true
-			fp.mu.Unlock()
-			return nil, fmt.Errorf("batch commit %w", err)
-		}
-		fp.mu.Lock()
-	}
 
 	// Release lock before waiting for commit response - handler needs lock to send to commitCh
 	fp.mu.Unlock()
 
-	// wait for commit ack or context cancel
+	deadline, ping, pingInterval := fp.newPingTimers()
+	defer deadline.Stop()
+	defer ping.Stop()
+
 	var batchAck *BatchAck
 	var commitErr error
-	select {
-	case commitResp := <-fp.commitCh:
-		if commitResp.Error != nil {
-			commitErr = commitResp.Error
-			break
+	for {
+		select {
+		case commitResp := <-fp.commitCh:
+			if commitResp.Error != nil {
+				commitErr = commitResp.Error
+			} else if commitResp.BatchAck == nil || commitResp.Stream == "" {
+				commitErr = ErrInvalidBatchAck
+			} else {
+				batchAck = commitResp.BatchAck
+			}
+		case <-ping.C:
+			if err := fp.sendPing(); err != nil {
+				commitErr = fmt.Errorf("ping failed: %w", err)
+				break
+			}
+			ping.Reset(pingInterval)
+			continue
+		case <-deadline.C:
+			commitErr = errors.New("ack timeout")
+		case <-ctx.Done():
+			fp.mu.Lock()
+			fp.closed = true
+			if fp.ackSub != nil {
+				fp.ackSub.Unsubscribe()
+				fp.ackSub = nil
+			}
+			fp.mu.Unlock()
+			return nil, ctx.Err()
 		}
-		if commitResp.BatchAck == nil || commitResp.Stream == "" {
-			commitErr = ErrInvalidBatchAck
-			break
-		}
-		batchAck = commitResp.BatchAck
-	case <-ctx.Done():
-		fp.mu.Lock()
-		fp.closed = true
-		if fp.ackSub != nil {
-			fp.ackSub.Unsubscribe()
-			fp.ackSub = nil
-		}
-		fp.mu.Unlock()
-		return nil, ctx.Err()
+		break
 	}
 
 	// Reacquire lock to safely modify shared state

--- a/jetstreamext/fastpublish.go
+++ b/jetstreamext/fastpublish.go
@@ -125,8 +125,7 @@ type (
 		js             jetstream.JetStream
 		flow           uint16
 		ackInboxPrefix string
-		// replyPrefix caches "<inbox>.<flow>.<gap>." to avoid fmt.Sprintf per message.
-		// Rebuilt when flow changes via server ack.
+		// replyPrefix caches "<inbox>.<flow>.<gap>." fixed at initialization; not rebuilt when flow changes.
 		replyPrefix  string
 		ackSub       *nats.Subscription
 		sequence     uint64
@@ -191,7 +190,13 @@ func NewFastPublisher(js jetstream.JetStream, opts ...FastPublisherOpt) (FastPub
 		opts:           pubOpts,
 		errHandler:     pubOpts.errHandler,
 	}
-	fp.buildReplyPrefix()
+
+	gap := "fail"
+	if fp.opts.continueOnGap {
+		gap = "ok"
+	}
+	fp.replyPrefix = fp.ackInboxPrefix + "." + strconv.FormatUint(uint64(fp.flow), 10) + "." + gap + "."
+
 	return fp, nil
 }
 
@@ -232,16 +237,6 @@ func (fp *fastPublisher) waitForStall(stallCh <-chan struct{}) error {
 			return errors.New("ack timeout")
 		}
 	}
-}
-
-// buildReplyPrefix pre-computes the stable portion of the reply subject:
-// "<inbox>.<flow>.<gap>." so that per-message we only append "<seq>.<op>.$FI".
-func (fp *fastPublisher) buildReplyPrefix() {
-	gap := "fail"
-	if fp.opts.continueOnGap {
-		gap = "ok"
-	}
-	fp.replyPrefix = fp.ackInboxPrefix + "." + strconv.FormatUint(uint64(fp.flow), 10) + "." + gap + "."
 }
 
 // buildReplySubject constructs the full reply subject using the cached prefix.
@@ -579,7 +574,6 @@ func (fp *fastPublisher) ackMsgHandler(msg *nats.Msg) {
 		if flowAck != nil {
 			if fp.flow != flowAck.Messages {
 				fp.flow = flowAck.Messages
-				fp.buildReplyPrefix()
 			}
 			fp.ackSequence = flowAck.Sequence
 			// Handle first message ack specially - firstAckCh is only set for first message

--- a/jetstreamext/fastpublish.go
+++ b/jetstreamext/fastpublish.go
@@ -349,8 +349,13 @@ func (fp *fastPublisher) AddMsg(msg *nats.Msg, opts ...BatchMsgOpt) (*FastPubAck
 
 	// other than first message, we just publish and track pending acks.
 	// if we exceed max outstanding acks, we stall until we get a flow ack.
+	seq := fp.sequence
+	if err := fp.js.Conn().PublishMsg(msg); err != nil {
+		fp.mu.Unlock()
+		return nil, fmt.Errorf("batch message %d publish failed: %w", seq, err)
+	}
 
-	waitForAck := fp.ackSequence+uint64(fp.flow)*uint64(fp.opts.maxOutstandingAcks) < fp.sequence
+	waitForAck := fp.ackSequence+uint64(fp.flow)*uint64(fp.opts.maxOutstandingAcks) <= fp.sequence
 	if waitForAck {
 		if fp.stallCh == nil {
 			fp.stallCh = make(chan struct{}, 1)
@@ -366,15 +371,8 @@ func (fp *fastPublisher) AddMsg(msg *nats.Msg, opts ...BatchMsgOpt) (*FastPubAck
 		fp.mu.Lock()
 	}
 
-	// Capture state under lock, then release before the publish I/O
-	// so the ack handler can process responses concurrently.
-	seq := fp.sequence
 	ackSeq := fp.ackSequence
 	fp.mu.Unlock()
-
-	if err := fp.js.Conn().PublishMsg(msg); err != nil {
-		return nil, fmt.Errorf("batch message %d publish failed: %w", seq, err)
-	}
 
 	return &FastPubAck{
 		BatchSequence: seq,
@@ -462,7 +460,11 @@ func (fp *fastPublisher) commit(ctx context.Context, msg *nats.Msg, eob bool) (*
 		}
 		fp.ackSub = ackSub
 	}
-	waitForAck := fp.ackSequence+uint64(fp.flow)*uint64(fp.opts.maxOutstandingAcks) < fp.sequence
+	if err := fp.js.Conn().PublishMsg(msg); err != nil {
+		fp.mu.Unlock()
+		return nil, fmt.Errorf("batch commit failed: %w", err)
+	}
+	waitForAck := fp.ackSequence+uint64(fp.flow)*uint64(fp.opts.maxOutstandingAcks) <= fp.sequence
 	if waitForAck {
 		if fp.stallCh == nil {
 			fp.stallCh = make(chan struct{}, 1)
@@ -476,10 +478,6 @@ func (fp *fastPublisher) commit(ctx context.Context, msg *nats.Msg, eob bool) (*
 			return nil, fmt.Errorf("batch commit %w", err)
 		}
 		fp.mu.Lock()
-	}
-	if err := fp.js.Conn().PublishMsg(msg); err != nil {
-		fp.mu.Unlock()
-		return nil, fmt.Errorf("batch commit failed: %w", err)
 	}
 
 	// Release lock before waiting for commit response - handler needs lock to send to commitCh

--- a/jetstreamext/publishbatch.go
+++ b/jetstreamext/publishbatch.go
@@ -107,13 +107,13 @@ type (
 		BatchID string `json:"batch,omitempty"`
 
 		// BatchSize is the number of messages in the batch.
-		BatchSize int `json:"count,omitempty"`
+		BatchSize uint64 `json:"count,omitempty"`
 	}
 
 	batchPublisher struct {
 		js       jetstream.JetStream
 		batchID  string
-		sequence int
+		sequence uint64
 		closed   bool
 		opts     batchPublishOpts
 		mu       sync.Mutex
@@ -222,13 +222,13 @@ func (b *batchPublisher) AddMsg(msg *nats.Msg, opts ...BatchMsgOpt) error {
 
 	b.sequence++
 	msg.Header.Set(BatchIDHeader, b.batchID)
-	msg.Header.Set(BatchSeqHeader, strconv.FormatUint(uint64(b.sequence), 10))
+	msg.Header.Set(BatchSeqHeader, strconv.FormatUint(b.sequence, 10))
 
 	// Determine if we need flow control for this message
 	var needsAck bool
 	if b.opts.flowControl.AckFirst && b.sequence == 1 {
 		needsAck = true // wait on first message
-	} else if b.opts.flowControl.AckEvery > 0 && b.sequence%b.opts.flowControl.AckEvery == 0 {
+	} else if b.opts.flowControl.AckEvery > 0 && b.sequence%uint64(b.opts.flowControl.AckEvery) == 0 {
 		needsAck = true // periodic flow control
 	}
 
@@ -306,7 +306,7 @@ func (b *batchPublisher) CommitMsg(ctx context.Context, msg *nats.Msg, opts ...B
 	b.sequence++
 
 	msg.Header.Set(BatchIDHeader, b.batchID)
-	msg.Header.Set(BatchSeqHeader, strconv.FormatUint(uint64(b.sequence), 10))
+	msg.Header.Set(BatchSeqHeader, strconv.FormatUint(b.sequence, 10))
 	msg.Header.Set(BatchCommitHeader, "1")
 
 	ctx, cancel = wrapContextWithoutDeadline(ctx, b.js)
@@ -333,7 +333,7 @@ func (b *batchPublisher) CommitMsg(ctx context.Context, msg *nats.Msg, opts ...B
 		return nil, batchResp.Error
 	}
 	if batchResp.BatchAck == nil || batchResp.Stream == "" ||
-		batchResp.BatchID != b.batchID || batchResp.BatchSize != int(b.sequence) {
+		batchResp.BatchID != b.batchID || batchResp.BatchSize != b.sequence {
 		return nil, ErrInvalidBatchAck
 	}
 
@@ -355,6 +355,8 @@ func (b *batchPublisher) Discard() error {
 }
 
 // Size returns the number of messages added to the batch so far.
+// Note: the return type is int to satisfy the BatchPublisher interface; the internal counter is
+// uint64, so batches exceeding math.MaxInt will be reported incorrectly.
 func (b *batchPublisher) Size() int {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -460,7 +462,7 @@ func PublishMsgBatch(ctx context.Context, js jetstream.JetStream, messages []*na
 			return nil, batchResp.Error
 		}
 		if batchResp.BatchAck == nil || batchResp.Stream == "" ||
-			batchResp.BatchID != batchID || batchResp.BatchSize != msgs {
+			batchResp.BatchID != batchID || batchResp.BatchSize != uint64(msgs) {
 
 			return nil, ErrInvalidBatchAck
 		}

--- a/jetstreamext/test/fastpublish_test.go
+++ b/jetstreamext/test/fastpublish_test.go
@@ -408,3 +408,57 @@ func TestFastPublisher_LargeBatch(t *testing.T) {
 		t.Fatalf("Expected BatchAck.BatchSize to be 100000, got %d", ack.BatchSize)
 	}
 }
+
+func TestFastPublisher_WaitForAckOnExactBoundary(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	defer shutdownJSServerAndRemoveStorage(t, s)
+	nc, js := jsClient(t, s)
+	defer nc.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:              "TEST",
+		Subjects:          []string{"test.>"},
+		AllowBatchPublish: true,
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error creating stream: %v", err)
+	}
+
+	// flow=1: ack every message, at most 1 outstanding ack at a time.
+	batch, err := jetstreamext.NewFastPublisher(js,
+		jetstreamext.FastPublishFlowControl{
+			Flow:               1,
+			MaxOutstandingAcks: 1,
+			AckTimeout:         5 * time.Second,
+		},
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error creating publisher: %v", err)
+	}
+
+	// Message 1 goes through the first-ack path and always waits.
+	_, err = batch.Add("test.msg", []byte("data"))
+	if err != nil {
+		t.Fatalf("Unexpected error adding msg 1: %v", err)
+	}
+
+	// Message 2: seq=2, ackSeq=1. Stall condition: 1+1 <= 2 = true.
+	// With old code (1+1 < 2 = false): no stall, AckSequence returned as 1. Additionally,
+	// if we would stall the ping timer would kick in and fail the batch due to there being a gap
+	// since the message wasn't sent right after increasing the sequence.
+	// With new code: sends first, stalls, waits for the server ack, AckSequence returned as 2.
+	ack2, err := batch.Add("test.msg", []byte("data"))
+	if err != nil {
+		t.Fatalf("Unexpected error adding msg 2: %v", err)
+	}
+	if ack2.AckSequence < ack2.BatchSequence {
+		t.Errorf("AckSequence %d < BatchSequence %d: publisher did not stall at the exact flow boundary; old code used '<' which skipped the stall when outstanding equalled flow*maxOA", ack2.AckSequence, ack2.BatchSequence)
+	}
+
+	if _, err = batch.Commit(ctx, "test.commit", []byte("commit")); err != nil {
+		t.Fatalf("Unexpected error committing: %v", err)
+	}
+}

--- a/jetstreamext/test/fastpublish_test.go
+++ b/jetstreamext/test/fastpublish_test.go
@@ -462,3 +462,51 @@ func TestFastPublisher_WaitForAckOnExactBoundary(t *testing.T) {
 		t.Fatalf("Unexpected error committing: %v", err)
 	}
 }
+
+func TestFastPublisher_StallEveryMessage(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	defer shutdownJSServerAndRemoveStorage(t, s)
+	nc, js := jsClient(t, s)
+	defer nc.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:              "TEST",
+		Subjects:          []string{"test.>"},
+		AllowBatchPublish: true,
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error creating stream: %v", err)
+	}
+
+	// flow=1, MaxOutstandingAcks=1: every message triggers a stall/unstall cycle.
+	// Stresses the persistent stall channel mechanics (send-not-close design
+	// that allows the channel to be reused across cycles).
+	batch, err := jetstreamext.NewFastPublisher(js,
+		jetstreamext.FastPublishFlowControl{
+			Flow:               1,
+			MaxOutstandingAcks: 1,
+			AckTimeout:         5 * time.Second,
+		},
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error creating publisher: %v", err)
+	}
+
+	const msgCount = 50
+	for i := range msgCount {
+		if _, err := batch.Add("test.msg", []byte("data")); err != nil {
+			t.Fatalf("Unexpected error adding message %d: %v", i, err)
+		}
+	}
+
+	ack, err := batch.Commit(ctx, "test.commit", []byte("commit"))
+	if err != nil {
+		t.Fatalf("Unexpected error committing: %v", err)
+	}
+	if ack.BatchSize != msgCount+1 {
+		t.Fatalf("Expected BatchSize %d, got %d", msgCount+1, ack.BatchSize)
+	}
+}

--- a/jetstreamext/test/fastpublish_test.go
+++ b/jetstreamext/test/fastpublish_test.go
@@ -409,6 +409,50 @@ func TestFastPublisher_LargeBatch(t *testing.T) {
 	}
 }
 
+func TestFastPublisher_CommitRespectsAckTimeout(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	defer shutdownJSServerAndRemoveStorage(t, s)
+	nc, js := jsClient(t, s)
+	defer nc.Close()
+
+	_, err := js.CreateStream(context.Background(), jetstream.StreamConfig{
+		Name:              "TEST",
+		Subjects:          []string{"test.>"},
+		AllowBatchPublish: true,
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error creating stream: %v", err)
+	}
+
+	batch, err := jetstreamext.NewFastPublisher(js,
+		jetstreamext.FastPublishFlowControl{
+			Flow:               1,
+			MaxOutstandingAcks: 1,
+			AckTimeout:         5 * time.Second,
+		},
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error creating publisher: %v", err)
+	}
+
+	for i := range 10 {
+		if _, err := batch.Add("test.msg", []byte("data")); err != nil {
+			t.Fatalf("Unexpected error adding message %d: %v", i, err)
+		}
+	}
+
+	// Commit with no deadline on the context. With the old code this would hang
+	// forever because the stall timer didn't watch for the commit ack. Now we wait for
+	// the commit and include pings and a deadline as well.
+	ack, err := batch.Commit(context.Background(), "test.commit", []byte("commit"))
+	if err != nil {
+		t.Fatalf("Unexpected error committing with context.Background(): %v", err)
+	}
+	if ack.BatchSize != 11 {
+		t.Fatalf("Expected BatchSize 11, got %d", ack.BatchSize)
+	}
+}
+
 func TestFastPublisher_WaitForAckOnExactBoundary(t *testing.T) {
 	s := RunBasicJetStreamServer()
 	defer shutdownJSServerAndRemoveStorage(t, s)

--- a/jetstreamext/test/fastpublish_test.go
+++ b/jetstreamext/test/fastpublish_test.go
@@ -15,7 +15,10 @@ package test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -268,6 +271,94 @@ func TestFastPublisher(t *testing.T) {
 			t.Fatalf("Expected ErrBatchClosed adding to discarded batch, got %v", err)
 		}
 	})
+}
+
+func TestFastPublisher_ReplyPrefixUnchangedOnFlowChange(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	defer shutdownJSServerAndRemoveStorage(t, s)
+	nc, js := jsClient(t, s)
+	defer nc.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:              "TEST",
+		Subjects:          []string{"test.>"},
+		AllowBatchPublish: true,
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error creating stream: %v", err)
+	}
+
+	// nc2 injects one flow ack with a lower flow value, if the reply subject is rewritten
+	// that shows the initial flow value is lost.
+	nc2 := client(t, s)
+	defer nc2.Close()
+	injectOnce := sync.Once{}
+	_, err = nc2.Subscribe("_INBOX.>", func(msg *nats.Msg) {
+		var ack struct {
+			Type     string `json:"type"`
+			Sequence uint64 `json:"seq"`
+			Messages uint16 `json:"msgs"`
+		}
+		if json.Unmarshal(msg.Data, &ack) != nil || ack.Type != "ack" {
+			return
+		}
+		injectOnce.Do(func() {
+			ack.Messages = 1
+			data, _ := json.Marshal(ack)
+			_ = nc2.Publish(msg.Subject, data)
+		})
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error subscribing: %v", err)
+	}
+
+	nc3 := client(t, s)
+	defer nc3.Close()
+	sub, err := nc3.SubscribeSync("test.msg")
+	if err != nil {
+		t.Fatalf("Unexpected error subscribing: %v", err)
+	}
+	if err = nc3.Flush(); err != nil {
+		t.Fatalf("Unexpected error flushing: %v", err)
+	}
+
+	batch, err := jetstreamext.NewFastPublisher(js,
+		jetstreamext.FastPublishFlowControl{
+			Flow:               10,
+			MaxOutstandingAcks: 5,
+			AckTimeout:         5 * time.Second,
+		},
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error creating publisher: %v", err)
+	}
+
+	const msgCount = 200
+	for i := range msgCount {
+		if _, err := batch.Add("test.msg", []byte("data")); err != nil {
+			t.Fatalf("Unexpected error adding message %d: %v", i, err)
+		}
+
+		// Inspect the reply subject of the messages that are published.
+		rmsg, err := sub.NextMsg(time.Second)
+		if err != nil {
+			t.Fatalf("Unexpected error receiving message: %v", err)
+		}
+		if !strings.Contains(rmsg.Reply, ".10.fail.") {
+			t.Fatalf("Initial flow in reply subject was overwritten: %q", rmsg.Reply)
+		}
+	}
+
+	ack, err := batch.Commit(ctx, "test.final", []byte("final"))
+	if err != nil {
+		t.Fatalf("Unexpected error committing batch: %v", err)
+	}
+	if ack.BatchSize != msgCount+1 {
+		t.Fatalf("Expected BatchSize %d, got %d", msgCount+1, ack.BatchSize)
+	}
 }
 
 func TestFastPublisher_LargeBatch(t *testing.T) {

--- a/jetstreamext/test/publishbatch_test.go
+++ b/jetstreamext/test/publishbatch_test.go
@@ -538,7 +538,7 @@ func TestPublishMsgBatch(t *testing.T) {
 		if info.State.Msgs != uint64(count) {
 			t.Fatalf("Expected %d messages in the stream, got %d", count, info.State.Msgs)
 		}
-		if ack.BatchSize != count {
+		if ack.BatchSize != uint64(count) {
 			t.Fatalf("Expected BatchAck.BatchSize to be %d, got %d", count, ack.BatchSize)
 		}
 	})


### PR DESCRIPTION
Several correctness and reliability bugs in `FastPublisher` could cause indefinite hangs, missed backpressure stalls, and inconsistent reply subjects when the server adjusts flow control during a batch.
                                                                                                                                                                                                                                              
- **Build reply prefix once at init**: the reply subject encodes the initial flow value negotiated with the server; rebuilding it on every flow-change ack was overwriting that value and breaking the reply routing contract.
- **Publish before checking stall condition**: reorders `AddMsg` to publish the message first and then wait for an ack if needed, fixing an off-by-one where the boundary condition (< vs <=) could skip a required stall at exactly the flow limit. Also fixes a bug where, because the data was not sent right after increasing the sequence, the ping operation could kick in and register as a gap, failing the batch.
- **Use uint64 for sequences**: aligns `BatchSize` and the internal sequence counter with `uint64`, aligned with this server PR/fix: https://github.com/nats-io/nats-server/pull/8094.
- **Recheck stall condition after receiving an ack**: a single ack signal on the stall channel doesn't guarantee we can proceed if throughput is high; adds a re-check loop in `waitForStall` so the publisher only resumes when truly unblocked.
- **Apply ping-and-deadline timeout to commit**: the commit path previously had no ack timeout of its own and would hang forever on context.Background(), or if `waitForStall` was called it could hang and return "commit timeout" even if the batch was committed. This gives it the same periodic-ping and deadline logic as `waitForStall` so the commit ack is preserved or times out cleanly.