### PR TITLE
Add docs.nats.io examples to main

### DIFF
--- a/jetstreamext/examples/atomicbatchdocs/main.go
+++ b/jetstreamext/examples/atomicbatchdocs/main.go
@@ -1,0 +1,71 @@
+// Copyright 2025 Synadia Communications Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/synadia-io/orbit.go/jetstreamext"
+)
+
+func main() {
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		log.Fatalf("connect: %v", err)
+	}
+	defer nc.Close()
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		log.Fatalf("new jetstream: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Atomic batch publishing requires the stream to be created with
+	// AllowAtomicPublish enabled (and nats-server v2.12.0 or later).
+	if _, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+		Name:               "ORDERS",
+		Subjects:           []string{"orders.>"},
+		AllowAtomicPublish: true,
+	}); err != nil {
+		log.Fatalf("create stream: %v", err)
+	}
+
+	// NATS-DOC-START
+	// Publish the three line items of order ORD-42 as one atomic batch:
+	// all three land in the ORDERS stream, or none do.
+	batch, err := jetstreamext.NewBatchPublisher(js)
+	if err != nil {
+		log.Fatalf("create batch publisher: %v", err)
+	}
+	if err := batch.Add("orders.created", []byte(`{"order":"ORD-42","sku":"COFFEE-1KG","qty":2}`)); err != nil {
+		log.Fatalf("add line item: %v", err)
+	}
+	if err := batch.Add("orders.created", []byte(`{"order":"ORD-42","sku":"FILTER-100","qty":1}`)); err != nil {
+		log.Fatalf("add line item: %v", err)
+	}
+	// Commit sends the final line item and atomically commits the batch.
+	ack, err := batch.Commit(ctx, "orders.created", []byte(`{"order":"ORD-42","sku":"MUG-WHITE","qty":4}`))
+	if err != nil {
+		log.Fatalf("commit batch: %v", err)
+	}
+	log.Printf("batch %q committed: %d line items stored", ack.BatchID, ack.BatchSize)
+	// NATS-DOC-END
+}

--- a/jetstreamext/examples/learn-jetstream-get-direct-batch-get/main.go
+++ b/jetstreamext/examples/learn-jetstream-get-direct-batch-get/main.go
@@ -1,0 +1,83 @@
+// Copyright 2025 Synadia Communications Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/synadia-io/orbit.go/jetstreamext"
+)
+
+func main() {
+	url := os.Getenv("NATS_URL")
+	if url == "" {
+		url = "nats://localhost:4222"
+	}
+
+	nc, err := nats.Connect(url)
+	if err != nil {
+		log.Fatalf("connect: %v", err)
+	}
+	defer nc.Close()
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		log.Fatalf("new jetstream: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Batch Direct Get reads straight from the stream's storage, so the
+	// stream must be created with AllowDirect enabled.
+	if _, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+		Name:        "ORDERS",
+		Subjects:    []string{"orders.>"},
+		AllowDirect: true,
+	}); err != nil {
+		log.Fatalf("create stream: %v", err)
+	}
+
+	// Seed the stream so there is something to read back.
+	for _, payload := range []string{
+		`{"order":"ORD-42","sku":"COFFEE-1KG","qty":2}`,
+		`{"order":"ORD-42","sku":"FILTER-100","qty":1}`,
+		`{"order":"ORD-42","sku":"MUG-WHITE","qty":4}`,
+	} {
+		if _, err := js.Publish(ctx, "orders.created", []byte(payload)); err != nil {
+			log.Fatalf("publish: %v", err)
+		}
+	}
+
+	// NATS-DOC-START
+	// Fetch up to 3 messages from ORDERS in a single Direct Get request,
+	// starting at stream sequence 1, and iterate them in order.
+	msgs, err := jetstreamext.GetBatch(ctx, js, "ORDERS", 3, jetstreamext.GetBatchSeq(1))
+	if err != nil {
+		log.Fatalf("get batch: %v", err)
+	}
+	for msg, err := range msgs {
+		if err != nil {
+			log.Fatalf("read message: %v", err)
+		}
+		fmt.Printf("seq %d on %s\n", msg.Sequence, msg.Subject)
+	}
+	// NATS-DOC-END
+}


### PR DESCRIPTION
Copies the two documentation examples from the `jetstream-docs` branch into `jetstreamext/examples/` on main (`atomicbatchdocs`, `learn-jetstream-get-direct-batch-get`). File-copy rather than branch merge — `jetstream-docs` branched off an older main and a merge would revert newer files.

Why: the new docs.nats.io build fetches these snippets at build time; on main the existing `jetstreamext.yaml` workflow (`go vet work`/`go test work`) compiles them automatically. Verified locally: `go vet ./examples/...` passes, gofmt-clean.

Note: please keep the `jetstream-docs` branch until the docs repo's fetch config is switched to `main` (follow-up PR there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)